### PR TITLE
fix: add base href for production builds

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Galeria Infinita com Webcam</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=5.0, minimum-scale=1.0">
+  <base href="/">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="manifest" href="manifest.webmanifest">
   <meta name="theme-color" content="#000000">


### PR DESCRIPTION
## Summary
- add base href to the document head so the Angular router resolves assets correctly in production deployments

## Testing
- npm run lint *(fails: Missing script "lint")*
- npm run typecheck *(fails: Missing script "typecheck")*

------
https://chatgpt.com/codex/tasks/task_e_69056c1693408321a40c2b3d651f1f6a