### PR TITLE
Add quick UTM copy action to campaign list

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -48,6 +48,38 @@
                      alt="Capa da Galeria: {{ item.name }}">
                 <div class="absolute inset-0 pointer-events-none shadow-[inset_0_0_40px_20px_rgba(0,0,0,0.8)] z-10"></div>
               </div>
+              <div
+                class="absolute top-3 right-3 z-20 flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200"
+                [class.opacity-100]="copiedGalleryId() === item.id"
+                (click)="$event.stopPropagation()">
+                <div class="relative flex items-center gap-2">
+                  <button
+                    type="button"
+                    (click)="copyCampaignLink($event, item)"
+                    class="p-2 rounded-full bg-black/60 hover:bg-black/80 transition-colors text-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-400"
+                    title="Copiar link UTM da campanha"
+                    aria-label="Copiar link UTM da campanha">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-4 h-4">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 8.25h-2.4A1.35 1.35 0 0 0 4.5 9.6v9.9a1.35 1.35 0 0 0 1.35 1.35h9.9a1.35 1.35 0 0 0 1.35-1.35v-2.4m-6.75-3h7.8a1.35 1.35 0 0 0 1.35-1.35V3.9A1.35 1.35 0 0 0 17.85 2.55h-7.8A1.35 1.35 0 0 0 8.7 3.9v7.8Z" />
+                    </svg>
+                  </button>
+                  <button
+                    type="button"
+                    (click)="openGalleryMenuFromButton($event, item.id)"
+                    class="p-2 rounded-full bg-black/60 hover:bg-black/80 transition-colors text-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-400"
+                    title="Abrir ações da campanha"
+                    aria-label="Abrir ações da campanha">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="w-4 h-4">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm0 6a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm0 6a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z" />
+                    </svg>
+                  </button>
+                  @if (copiedGalleryId() === item.id) {
+                    <span class="absolute -bottom-8 right-0 z-30 px-2 py-1 text-xs font-medium text-white bg-black/80 rounded-md shadow-lg">
+                      Link copiado!
+                    </span>
+                  }
+                </div>
+              </div>
               <div class="absolute bottom-0 left-0 pl-8 pb-8 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300">
                 <div class="text-xs text-gray-300 mb-0.5">{{ item.createdAt }}</div>
                 <div class="text-sm font-medium">{{ item.name }}</div>

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -206,6 +206,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   expandedItem = signal<ExpandedItem | null>(null);
   isWebcamVisible = signal(false);
   contextMenu = signal<{ visible: boolean; x: number; y: number; options?: string[] }>({ visible: false, x: 0, y: 0 });
+  copiedGalleryId = signal<string | null>(null);
   isDragging = signal(false);
   
   isFullscreen = signal(false);
@@ -237,6 +238,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   
   // --- Propriedades para o Context Menu ---
   private contextMenuGalleryId: string | null = null;
+  private copyFeedbackTimeout: ReturnType<typeof setTimeout> | null = null;
   
   canDrag = computed(() => !this.expandedItem() && !this.isWebcamVisible() && !this.isGalleryEditorVisible() && !this.isGalleryCreationDialogVisible() && !this.isInfoDialogVisible());
 
@@ -611,6 +613,51 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     this.updateVisibleItems(true); // Refresh the view
   }
 
+  copyCampaignLink(event: MouseEvent, gallery: GalleryCardItem): void {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const campaignLink = this.buildCampaignUtmLink(gallery);
+
+    if (!campaignLink) {
+      console.warn('Unable to build the campaign link.');
+      return;
+    }
+
+    if (!navigator?.clipboard) {
+      console.warn('Clipboard API is not available in this environment.');
+      this.copiedGalleryId.set(gallery.id);
+      this.scheduleCopyFeedbackReset();
+      return;
+    }
+
+    navigator.clipboard.writeText(campaignLink)
+      .then(() => {
+        this.copiedGalleryId.set(gallery.id);
+        this.scheduleCopyFeedbackReset();
+      })
+      .catch(error => {
+        console.error('Failed to copy campaign link', error);
+      });
+  }
+
+  openGalleryMenuFromButton(event: MouseEvent, galleryId: string): void {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const target = event.currentTarget as HTMLElement | null;
+    const rect = target?.getBoundingClientRect();
+
+    this.contextMenu.set({
+      visible: true,
+      x: rect ? rect.left : event.clientX,
+      y: rect ? rect.bottom + 4 : event.clientY,
+      options: ['editGallery', 'deleteGallery']
+    });
+
+    this.contextMenuGalleryId = galleryId;
+  }
+
   onRightClick(event: MouseEvent): void {
     event.preventDefault();
     if (this.currentView() === 'galleries') {
@@ -618,6 +665,44 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     } else {
       this.contextMenu.set({ visible: true, x: event.clientX, y: event.clientY, options: ['capturePhoto'] });
     }
+  }
+
+  private scheduleCopyFeedbackReset(): void {
+    if (this.copyFeedbackTimeout) {
+      clearTimeout(this.copyFeedbackTimeout);
+    }
+
+    this.copyFeedbackTimeout = setTimeout(() => {
+      this.copiedGalleryId.set(null);
+      this.copyFeedbackTimeout = null;
+    }, 2000);
+  }
+
+  private buildCampaignUtmLink(gallery: GalleryCardItem): string {
+    if (typeof window === 'undefined') {
+      return '';
+    }
+
+    const url = new URL(window.location.href);
+    url.hash = '';
+    url.search = '';
+    const campaignSlug = this.slugify(gallery.name) || gallery.id;
+
+    url.searchParams.set('utm_source', 'gallery_app');
+    url.searchParams.set('utm_medium', 'card_menu');
+    url.searchParams.set('utm_campaign', campaignSlug);
+    url.searchParams.set('campaignId', gallery.id);
+
+    return url.toString();
+  }
+
+  private slugify(value: string): string {
+    return value
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^a-zA-Z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .toLowerCase();
   }
   
   onGalleryRightClick(event: MouseEvent, galleryId: string): void {


### PR DESCRIPTION
## Summary
- adiciona botão de cópia rápida ao lado do menu de ações das campanhas
- gera link UTM padronizado e apresenta feedback visual ao copiar
- permite abrir o menu de opções da campanha a partir do botão de três pontos

## Testing
- npm run lint *(fails: script not found)*
- npm run typecheck *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_6905f92500308321868ef25f66f6452a