### PR TITLE
Adiciona atalho de teclado para sair da galeria com Q

### DIFF
--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -119,21 +119,48 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     // Check if user is typing in an input field, textarea, or contenteditable element
     const target = event.target as HTMLElement;
     const isTyping = target && (
-      target.tagName === 'INPUT' || 
-      target.tagName === 'TEXTAREA' || 
+      target.tagName === 'INPUT' ||
+      target.tagName === 'TEXTAREA' ||
       target.isContentEditable ||
       target.closest('input') ||
       target.closest('textarea')
     );
-    
+
     if (isTyping) {
       // Allow 'i' to be typed normally in input fields
       return;
     }
-    
+
     event.preventDefault();
     // Toggle info dialog - if already open, it will close; if closed, it will open
     this.toggleInfoDialog();
+  }
+
+  @HostListener('document:keydown.q', ['$event'])
+  handleQuitGalleryKey(event: KeyboardEvent): void {
+    const target = event.target as HTMLElement | null;
+    const isTyping = !!target && (
+      target.tagName === 'INPUT' ||
+      target.tagName === 'TEXTAREA' ||
+      target.isContentEditable ||
+      !!target.closest('input') ||
+      !!target.closest('textarea')
+    );
+
+    if (isTyping) {
+      return;
+    }
+
+    if (
+      this.currentView() === 'photos' &&
+      !this.expandedItem() &&
+      !this.isGalleryEditorVisible() &&
+      !this.isGalleryCreationDialogVisible() &&
+      !this.isWebcamVisible()
+    ) {
+      event.preventDefault();
+      this.backToGalleries();
+    }
   }
 
   @HostListener('document:keydown', ['$event'])


### PR DESCRIPTION
## Summary
- adiciona um ouvinte de teclado para permitir que a tecla "q" retorne à lista de galerias quando o usuário estiver visualizando fotos
- evita que o atalho seja acionado durante digitação ou quando diálogos, webcam ou itens expandidos estiverem ativos

## Testing
- npm run lint *(fails: Missing script "lint")*
- npm run typecheck *(fails: Missing script "typecheck")*

------
https://chatgpt.com/codex/tasks/task_e_690601bc638c83219716de7f5a8c1dc3