### PR TITLE
Atualiza rótulo do contador de galerias e fotos

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -169,9 +169,9 @@
   <!-- Contador de Galerias ou Fotos -->
   <div class="absolute top-4 right-4 text-sm font-mono tracking-widest text-gray-700 z-20 pointer-events-none">
     @if (currentView() === 'galleries') {
-      Galerias: {{ galleryCount() }}
+      {{ galleryCounterLabel() }} {{ galleryCount() }}
     } @else {
-      Fotos: {{ photoCount() }}
+      {{ photoCounterLabel() }} {{ photoCount() }}
     }
   </div>
 

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -208,6 +208,8 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   // --- Sinais para Contagem de Fotos e Galerias ---
   photoCount = computed(() => this.images().length);
   galleryCount = computed(() => this.galleryService.galleries().length);
+  photoCounterLabel = computed(() => (this.photoCount() <= 1 ? "f.0" : "f's.00"));
+  galleryCounterLabel = computed(() => (this.galleryCount() <= 1 ? "g.0" : "g's.00"));
 
   // --- Sinais para o Editor de Galeria ---
   isGalleryEditorVisible = signal(false);


### PR DESCRIPTION
## Summary
- ajusta os rótulos do contador no canto superior direito para exibir g.0/g's.00 e f.0/f's.00 conforme a quantidade de itens

## Testing
- npm run lint *(fails: Missing script "lint")*
- npm run typecheck *(fails: Missing script "typecheck")*

------
https://chatgpt.com/codex/tasks/task_e_6906039978c48321b0dce5f187a93c25