### PR TITLE
Add creation order hover badges

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -45,6 +45,10 @@
                      alt="Capa da Galeria: {{ item.name }}">
                 <div class="absolute inset-0 pointer-events-none shadow-[inset_0_0_40px_20px_rgba(0,0,0,0.8)] z-10"></div>
               </div>
+              <span
+                class="absolute top-2 right-2 z-30 px-1.5 py-0.5 text-[10px] font-semibold text-gray-200 bg-black/50 rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
+                {{ item.creationOrder }}
+              </span>
               <div
                 class="absolute top-3 right-3 z-20 flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200"
                 [class.opacity-100]="copiedGalleryId() === item.id"
@@ -135,6 +139,10 @@
               }
               <div class="absolute inset-0 pointer-events-none shadow-[inset_0_0_40px_20px_rgba(0,0,0,0.8)] z-10"></div>
             </div>
+            <span
+              class="absolute top-2 right-2 z-30 px-1.5 py-0.5 text-[10px] font-semibold text-gray-200 bg-black/50 rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
+              {{ item.creationOrder }}
+            </span>
         </div>
       }
     </div>

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -20,6 +20,7 @@ interface BaseItem {
   height: number;
   col: number;
   row: number;
+  creationOrder: number;
 }
 
 interface PhotoItem extends BaseItem {
@@ -536,6 +537,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
       for (let col = startCol; col <= endCol; col++) {
         const itemIndex = Math.abs((row * this.numColumns() + col) % itemsToDisplay.length);
         const currentItem = itemsToDisplay[itemIndex];
+        const creationOrder = this.calculateCreationOrder(itemsToDisplay.length, itemIndex);
 
         if (isGalleryView) {
           const gallery = currentItem as Gallery;
@@ -553,6 +555,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
             height: this.itemDimensions.height,
             col,
             row,
+            creationOrder,
           });
         } else {
           const imageUrl = currentItem as string;
@@ -566,11 +569,19 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
             height: this.itemDimensions.height,
             col,
             row,
+            creationOrder,
           });
         }
       }
     }
     this.visibleItems.set(newVisibleItems);
+  }
+
+  private calculateCreationOrder(totalItems: number, index: number): number {
+    if (totalItems <= 0) {
+      return 0;
+    }
+    return totalItems - index;
   }
 
   private startAnimationLoop(): void {


### PR DESCRIPTION
## Summary
- calcula a ordem de criação dos itens visíveis considerando a posição na lista original
- exibe um selo discreto com a ordem de criação ao passar o mouse sobre galerias e fotos

## Testing
- npm run lint *(fails: Missing script "lint")*
- npm run typecheck *(fails: Missing script "typecheck")*

------
https://chatgpt.com/codex/tasks/task_e_69060f9908888321b281f79dcb57b80b