### PR TITLE
feat: add gallery hover preview slideshow

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -36,9 +36,11 @@
               [style.top.px]="item.y"
               [class.cursor-pointer]="isInteractionEnabled()"
               (click)="selectGallery(item.id)"
+              (mouseenter)="onGalleryHoverStart(item.id)"
+              (mouseleave)="onGalleryHoverEnd(item.id)"
               (contextmenu)="onGalleryRightClick($event, item.id)">
               <div class="item-image-container relative w-full h-full overflow-hidden">
-                <img [src]="item.thumbnailUrl || 'https://via.placeholder.com/150?text=No+Image'"
+                <img [src]="galleryPreviewImages()[item.id] ?? item.thumbnailUrl"
                      class="w-full h-full object-cover pointer-events-none transition-opacity duration-400 opacity-0"
                      (load)="$event.target.classList.add('opacity-100')"
                      [class.group-hover:scale-105]="isInteractionEnabled()"


### PR DESCRIPTION
## Summary
- adiciona uma pré-visualização animada das fotos da galeria quando o cartão recebe hover
- gerencia timers e limpeza dos estados de pré-visualização para evitar vazamentos ao trocar de tela ou sair do hover

## Testing
- npm run lint *(falhou: script ausente)*
- npm run typecheck *(falhou: script ausente)*

------
https://chatgpt.com/codex/tasks/task_e_69061916629083218c39bba60b4f1c22