### PR TITLE
Garantir pré-visualização exclusiva por card de galeria

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -36,11 +36,11 @@
               [style.top.px]="item.y"
               [class.cursor-pointer]="isInteractionEnabled()"
               (click)="selectGallery(item.id)"
-              (mouseenter)="onGalleryHoverStart(item.id)"
-              (mouseleave)="onGalleryHoverEnd(item.id)"
+              (mouseenter)="onGalleryHoverStart(item.id, item.previewKey)"
+              (mouseleave)="onGalleryHoverEnd(item.previewKey)"
               (contextmenu)="onGalleryRightClick($event, item.id)">
               <div class="item-image-container relative w-full h-full overflow-hidden">
-                <img [src]="galleryPreviewImages()[item.id] ?? item.thumbnailUrl"
+                <img [src]="galleryPreviewImages()[item.previewKey] ?? item.thumbnailUrl"
                      class="w-full h-full object-cover pointer-events-none transition-opacity duration-400 opacity-0"
                      (load)="$event.target.classList.add('opacity-100')"
                      [class.group-hover:scale-105]="isInteractionEnabled()"


### PR DESCRIPTION
## Summary
- introduzir uma chave única por instância de card de galeria para controlar a pré-visualização
- atualizar os manipuladores de hover para usar essa chave e evitar que clones sincronizem imagens
- ajustar o template e a função trackBy para refletir a nova chave de instância

## Testing
- npm run lint *(fails: script missing)*
- npm run typecheck *(fails: script missing)*

------
https://chatgpt.com/codex/tasks/task_e_69061c504c68832194baa471803f2130