### PR TITLE
Add opt-out guard for Microsoft Clarity tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,45 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/gsap.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/CustomEase.min.js"></script>
+  <script type="text/javascript">
+    (function () {
+      var clarityOptOut = false;
+
+      try {
+        clarityOptOut =
+          localStorage.getItem("clarityOptOut") === "true" ||
+          document.cookie
+            .split(";")
+            .some(function (cookie) {
+              return cookie.trim() === "clarityOptOut=true";
+            });
+      } catch (error) {
+        clarityOptOut = false;
+      }
+
+      if (clarityOptOut) {
+        window.clarity =
+          window.clarity ||
+          function () {
+            /* no-op: usuário opt-out */
+          };
+        return;
+      }
+
+      (function (c, l, a, r, i, t, y) {
+        c[a] =
+          c[a] ||
+          function () {
+            (c[a].q = c[a].q || []).push(arguments);
+          };
+        t = l.createElement(r);
+        t.async = 1;
+        t.src = "https://www.clarity.ms/tag/" + i;
+        y = l.getElementsByTagName(r)[0];
+        y.parentNode.insertBefore(t, y);
+      })(window, document, "clarity", "script", "tzisvdqjwu");
+    })();
+  </script>
   <style>
     body {
       background-color: #000000;


### PR DESCRIPTION
## Summary
- wrap the Microsoft Clarity loader with an opt-out guard that checks for a local cookie or localStorage flag
- keep a no-op clarity stub when the opt-out flag is present so other scripts do not break

## Testing
- npm run lint *(fails: Missing script "lint")*
- npm run typecheck *(fails: Missing script "typecheck")*

------
https://chatgpt.com/codex/tasks/task_e_690691e429ac8321b1ddf7089481958d