### PR TITLE
Remove zero padding from counter labels

### DIFF
--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -273,8 +273,8 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   // --- Sinais para Contagem de Fotos e Galerias ---
   photoCount = computed(() => this.images().length);
   galleryCount = computed(() => this.galleryService.galleries().length);
-  photoCounterLabel = computed(() => (this.photoCount() <= 1 ? "f.0" : "f's.00"));
-  galleryCounterLabel = computed(() => (this.galleryCount() <= 1 ? "g.0" : "g's.00"));
+  photoCounterLabel = computed(() => (this.photoCount() <= 1 ? "f." : "f's."));
+  galleryCounterLabel = computed(() => (this.galleryCount() <= 1 ? "g." : "g's."));
 
   // --- Sinais para o Editor de Galeria ---
   isGalleryEditorVisible = signal(false);


### PR DESCRIPTION
## Summary
- update the photo and gallery counter labels to remove zero padding so they display as `f.`/`f's.` and `g.`/`g's.`

## Testing
- npm run lint *(fails: Missing script "lint")*
- npm run typecheck *(fails: Missing script "typecheck")*

------
https://chatgpt.com/codex/tasks/task_e_69069cbc3bd08321a96ef99b7f019ef1