### PR TITLE
Add interactive cursor animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,5 +131,6 @@
 </head>
 <body class="antialiased font-sans bg-black text-gray-300">
   <app-root></app-root>
+  <div class="custom-cursor"></div>
 </body>
 </html>

--- a/src/app.component.html
+++ b/src/app.component.html
@@ -31,6 +31,7 @@
           @if (item.type === 'gallery') {
             <div
               class="item group absolute overflow-hidden bg-[#1a1a1a] rounded-lg"
+              data-hover-target
               [style.width.px]="item.width"
               [style.height.px]="item.height"
               [style.left.px]="item.x"
@@ -40,6 +41,7 @@
               (mouseenter)="onGalleryHoverStart(item.id, item.previewKey)"
               (mouseleave)="onGalleryHoverEnd(item.previewKey)"
               (contextmenu)="onGalleryRightClick($event, item.id)">
+              <div data-hover-trigger class="absolute inset-0 z-40"></div>
               <div class="item-image-container relative w-full h-full overflow-hidden">
                 <img [src]="galleryPreviewImages()[item.previewKey] ?? item.thumbnailUrl"
                      class="w-full h-full object-cover pointer-events-none transition-opacity duration-400 opacity-0"
@@ -94,12 +96,14 @@
       @for (item of visibleItems(); track trackById($index, item)) {
         <div
           class="item group absolute overflow-hidden bg-[#1a1a1a] rounded-lg"
+          data-hover-target
           [style.width.px]="item.width"
           [style.height.px]="item.height"
           [style.left.px]="item.x"
           [style.top.px]="item.y"
           [class.cursor-pointer]="isInteractionEnabled()"
           (click)="onImageClick($event, item)">
+            <div data-hover-trigger class="absolute inset-0 z-40"></div>
             <div class="item-image-container relative w-full h-full overflow-hidden">
               @if (item.type === 'photo') {
                 <img [src]="item.url"

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,10 +3,17 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideZonelessChangeDetection } from '@angular/core';
 
 import { AppComponent } from './app.component';
+import { initializeInteractiveCursor } from './utils/interactive-cursor';
 
 bootstrapApplication(AppComponent, {
   providers: [
     provideZonelessChangeDetection(),
     provideHttpClient(),
   ],
-});
+})
+  .then(() => {
+    initializeInteractiveCursor();
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/src/styles.css
+++ b/src/styles.css
@@ -24,3 +24,43 @@ app-gallery-editor textarea:focus {
   outline: none !important;
   outline-color: transparent !important;
 }
+
+/* --- CSS Essencial para o Cursor Interativo --- */
+body {
+  cursor: none;
+}
+
+.custom-cursor {
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: 1000;
+  pointer-events: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 5px;
+  background-color: #f2f2f2;
+  opacity: 0.8;
+  mix-blend-mode: difference;
+  transition: opacity 0.2s ease;
+}
+
+[data-hover-target] {
+  position: relative;
+}
+
+[data-hover-trigger] {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+}
+
+@media (pointer: coarse) {
+  body {
+    cursor: auto;
+  }
+
+  .custom-cursor {
+    display: none;
+  }
+}

--- a/src/utils/interactive-cursor.ts
+++ b/src/utils/interactive-cursor.ts
@@ -1,0 +1,153 @@
+interface Vector2 {
+  x: number;
+  y: number;
+  lerp(target: Vector2, amount: number): void;
+}
+
+const createVector2 = (x: number, y: number): Vector2 => ({
+  x,
+  y,
+  lerp(target: Vector2, amount: number) {
+    this.x += (target.x - this.x) * amount;
+    this.y += (target.y - this.y) * amount;
+  },
+});
+
+type TickerCallback = (time: number, deltaTime: number, frame: number) => void;
+
+interface GsapLike {
+  set(target: Element | Element[] | NodeListOf<Element> | string, vars: Record<string, unknown>): void;
+  to(target: Element | Element[] | NodeListOf<Element> | string, vars: Record<string, unknown>): void;
+  killTweensOf(target: Element | Element[] | NodeListOf<Element> | string): void;
+  ticker: {
+    add(callback: TickerCallback): void;
+    remove(callback: TickerCallback): void;
+  };
+}
+
+declare global {
+  interface Window {
+    gsap?: GsapLike;
+  }
+}
+
+class InteractiveCursor {
+  private readonly gsap: GsapLike;
+
+  private readonly position = {
+    target: createVector2(window.innerWidth / 2, window.innerHeight / 2),
+    current: createVector2(window.innerWidth / 2, window.innerHeight / 2),
+    lerpAmount: 0.2,
+  };
+
+  private isHoveringTarget = false;
+
+  private readonly updateTick = () => {
+    this.position.current.lerp(this.position.target, this.position.lerpAmount);
+
+    if (!this.isHoveringTarget) {
+      this.gsap.set(this.cursor, {
+        x: this.position.current.x,
+        y: this.position.current.y,
+      });
+    }
+  };
+
+  private readonly handlePointerMove = (event: PointerEvent) => {
+    this.position.target.x = event.clientX;
+    this.position.target.y = event.clientY;
+  };
+
+  private readonly handlePointerEnter = (event: Event) => {
+    const trigger = (event.target as HTMLElement | null)?.closest<HTMLElement>('[data-hover-trigger]');
+    if (!trigger) {
+      return;
+    }
+
+    const targetElement = trigger.closest<HTMLElement>('[data-hover-target]');
+    if (!targetElement) {
+      return;
+    }
+
+    const targetRect = targetElement.getBoundingClientRect();
+    this.isHoveringTarget = true;
+
+    this.gsap.to(this.cursor, {
+      x: targetRect.left,
+      y: targetRect.top,
+      width: targetRect.width,
+      height: targetRect.height,
+      borderRadius: '10px',
+      duration: 0.5,
+      ease: 'power4.out',
+      overwrite: true,
+      xPercent: 0,
+      yPercent: 0,
+    });
+  };
+
+  private readonly handlePointerLeave = (event: Event) => {
+    const trigger = (event.target as HTMLElement | null)?.closest<HTMLElement>('[data-hover-trigger]');
+    if (!trigger) {
+      return;
+    }
+
+    this.isHoveringTarget = false;
+
+    this.gsap.killTweensOf(this.cursor);
+
+    this.position.current.x = this.position.target.x;
+    this.position.current.y = this.position.target.y;
+
+    this.gsap.to(this.cursor, {
+      width: 20,
+      height: 20,
+      borderRadius: '5px',
+      duration: 0.5,
+      ease: 'power4.out',
+      overwrite: true,
+      xPercent: -50,
+      yPercent: -50,
+    });
+  };
+
+  constructor(private readonly cursor: HTMLElement, gsapInstance: GsapLike) {
+    this.gsap = gsapInstance;
+    this.init();
+  }
+
+  private init(): void {
+    this.gsap.set(this.cursor, { xPercent: -50, yPercent: -50 });
+    this.gsap.ticker.add(this.updateTick);
+
+    window.addEventListener('pointermove', this.handlePointerMove);
+    document.addEventListener('pointerenter', this.handlePointerEnter, true);
+    document.addEventListener('pointerleave', this.handlePointerLeave, true);
+  }
+}
+
+let interactiveCursorInstance: InteractiveCursor | null = null;
+
+export const initializeInteractiveCursor = (): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (interactiveCursorInstance) {
+    return;
+  }
+
+  const gsapInstance = window.gsap;
+  if (!gsapInstance) {
+    console.warn('GSAP não está disponível. O cursor interativo não será inicializado.');
+    return;
+  }
+
+  const cursorElement = document.querySelector<HTMLElement>('.custom-cursor');
+  if (!cursorElement) {
+    console.warn('Elemento do cursor customizado não encontrado.');
+    return;
+  }
+
+  interactiveCursorInstance = new InteractiveCursor(cursorElement, gsapInstance);
+};


### PR DESCRIPTION
## Summary
- adiciona o contêiner do cursor customizado ao HTML principal e estilos globais para ocultar o cursor nativo
- marca itens de galeria e fotos com data attributes para que o cursor acompanhe e envolva cada alvo
- inicializa um cursor interativo baseado em GSAP após o bootstrap da aplicação com listeners delegados

## Testing
- npm run lint *(erro: Missing script "lint")*
- npm run typecheck *(erro: Missing script "typecheck")*

------
https://chatgpt.com/codex/tasks/task_e_6907622c2c9883218c85846b9bebcdfd