### PR TITLE
Fix light mode backgrounds for gallery and info dialog

### DIFF
--- a/src/app.component.css
+++ b/src/app.component.css
@@ -3,5 +3,4 @@
   width: 100vw;
   height: 100vh;
   user-select: none;
-  background-color: black;
 }

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, signal, inject, computed, effect, viewChild, ElementRef, OnInit, AfterViewInit, OnDestroy, NgZone, HostListener } from '@angular/core';
+import { Component, ChangeDetectionStrategy, signal, inject, computed, effect, viewChild, ElementRef, OnInit, AfterViewInit, OnDestroy, NgZone, HostListener, HostBinding } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { GalleryService } from './services/gallery.service';
 import { ContextMenuComponent } from './components/context-menu/context-menu.component';
@@ -67,6 +67,16 @@ interface ExpandedItem {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
+  @HostBinding('style.background-color')
+  get hostBackgroundColor(): string {
+    return this.themeService.bodyBackground();
+  }
+
+  @HostBinding('style.color')
+  get hostTextColor(): string {
+    return this.themeService.bodyText();
+  }
+
   @HostListener('document:keydown.space', ['$event'])
   handleSpacebar(event?: KeyboardEvent | MouseEvent): void {
     if (event instanceof KeyboardEvent) {

--- a/src/components/info-dialog/info-dialog.component.ts
+++ b/src/components/info-dialog/info-dialog.component.ts
@@ -30,7 +30,11 @@ import { ThemeService } from '../../services/theme.service';
       </div>
 
       <!-- Content in three columns -->
-      <div class="flex-1 overflow-y-auto p-8" [style.color]="themeService.dialogPalette().text">
+      <div
+        class="flex-1 overflow-y-auto p-8"
+        [style.color]="themeService.dialogPalette().text"
+        [style.backgroundColor]="themeService.dialogPalette().surface"
+      >
         <div class="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-12">
 
           <!-- Column 1: Apresentação -->

--- a/src/services/theme.service.ts
+++ b/src/services/theme.service.ts
@@ -133,6 +133,8 @@ export class ThemeService {
   readonly contextMenuPalette = computed(() => this.palettes[this.themeSignal()].contextMenu);
   readonly dialogPalette = computed(() => this.palettes[this.themeSignal()].dialog);
   readonly scrimColor = computed(() => this.palettes[this.themeSignal()].scrim);
+  readonly bodyBackground = computed(() => this.palettes[this.themeSignal()].bodyBackground);
+  readonly bodyText = computed(() => this.palettes[this.themeSignal()].bodyText);
 
   constructor(@Inject(DOCUMENT) private readonly documentRef: Document) {
     effect(() => {


### PR DESCRIPTION
## Summary
- expose the body background and text colors from the theme service so other components can react to light mode changes
- bind the root component host styles to the active theme instead of forcing a black background
- apply the dialog surface palette to the info dialog content to reflect the selected theme

## Testing
- npm run lint *(fails: script not found)*
- npm run typecheck *(fails: script not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691475d211cc832189b20e4e44727d39)