### PR TITLE
Ameniza artefatos óticos no tema claro

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -1,7 +1,9 @@
 <!-- Container principal da galeria com listeners para interação -->
 <div
-  class="relative h-full w-full overflow-hidden select-none grayscale"
+  class="relative h-full w-full overflow-hidden select-none grayscale transition-colors duration-500"
   [class.cursor-none]="isIdle()"
+  [class.bg-black]="themeService.isDark()"
+  [class.bg-slate-100]="themeService.isLight()"
   [class.p-8]="!isMobileLayout()"
   (contextmenu)="onRightClick($event)">
 
@@ -168,7 +170,11 @@
           @for (item of visibleItems(); track trackById($index, item)) {
             @if (item.type === 'gallery') {
               <div
-                class="item group absolute overflow-hidden rounded-lg bg-[#1a1a1a]"
+                class="item group absolute overflow-hidden rounded-2xl bg-[#1a1a1a] ring-1 transition-[background-color,box-shadow,border-radius] duration-500"
+                [class.rounded-[2.5rem]]="themeService.isLight()"
+                [class.ring-white\/10]="themeService.isDark()"
+                [class.ring-slate-300\/60]="themeService.isLight()"
+                [class.bg-slate-100]="themeService.isLight()"
                 [style.width.px]="item.width"
                 [style.height.px]="item.height"
                 [style.left.px]="item.x"
@@ -186,7 +192,11 @@
                        (load)="$event.target.classList.add('opacity-100')"
                        [class.group-hover:scale-105]="isInteractionEnabled()"
                        alt="Capa da Galeria: {{ item.name }}">
-                  <div class="pointer-events-none absolute inset-0 z-10 shadow-[inset_0_0_40px_20px_rgba(0,0,0,0.8)]"></div>
+                  <div
+                    class="pointer-events-none absolute inset-0 z-10 transition-[box-shadow] duration-500"
+                    [class.shadow-\[inset_0_0_40px_20px_rgba\(0,0,0,0\.8\)\]]="themeService.isDark()"
+                    [class.shadow-\[inset_0_0_28px_18px_rgba\(15,23,42,0\.22\)\]]="themeService.isLight()"
+                  ></div>
                 </div>
                 <span
                   class="pointer-events-none absolute right-2 top-2 z-30 rounded-full bg-black/50 px-1.5 py-0.5 text-[10px] font-semibold text-gray-200 opacity-0 transition-opacity duration-200 group-hover:opacity-100"
@@ -236,7 +246,11 @@
       <div #canvas class="absolute will-change-transform">
         @for (item of visibleItems(); track trackById($index, item)) {
           <div
-            class="item group absolute overflow-hidden rounded-lg bg-[#1a1a1a]"
+            class="item group absolute overflow-hidden rounded-2xl bg-[#1a1a1a] ring-1 transition-[background-color,box-shadow,border-radius] duration-500"
+            [class.rounded-[2.5rem]]="themeService.isLight()"
+            [class.ring-white\/10]="themeService.isDark()"
+            [class.ring-slate-300\/60]="themeService.isLight()"
+            [class.bg-slate-100]="themeService.isLight()"
             [style.width.px]="item.width"
             [style.height.px]="item.height"
             [style.left.px]="item.x"
@@ -253,7 +267,11 @@
                      [class.group-hover:scale-1.05]="isInteractionEnabled()"
                      alt="Imagem da galeria capturada pela webcam">
               }
-              <div class="pointer-events-none absolute inset-0 z-10 shadow-[inset_0_0_40px_20px_rgba(0,0,0,0.8)]"></div>
+              <div
+                class="pointer-events-none absolute inset-0 z-10 transition-[box-shadow] duration-500"
+                [class.shadow-\[inset_0_0_40px_20px_rgba\(0,0,0,0\.8\)\]]="themeService.isDark()"
+                [class.shadow-\[inset_0_0_28px_18px_rgba\(15,23,42,0\.22\)\]]="themeService.isLight()"
+              ></div>
             </div>
             <span
               class="pointer-events-none absolute right-2 top-2 z-30 rounded-full bg-black/50 px-1.5 py-0.5 text-[10px] font-semibold text-gray-200 opacity-0 transition-opacity duration-200 group-hover:opacity-100"


### PR DESCRIPTION
## Summary
- aplica fundo claro controlado pelo serviço de tema diretamente no container principal da galeria
- ajusta cards para usarem raio maior, anel suave e sombras específicas para cada tema, reduzindo o contraste nos cruzamentos
- suaviza a camada de vinheta interna das miniaturas no modo claro para evitar pontos escuros percebidos

## Testing
- npm run lint *(fails: Missing script "lint")*
- npm run typecheck *(fails: Missing script "typecheck")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69147d8af5388321b98970eb46907aee)