### PR TITLE
Corrige animação de pré-visualização e contador de modo

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -337,10 +337,15 @@
 </div>
 
 @if (previewCountdown() !== null) {
-  <div
-    class="pointer-events-none fixed left-1/2 top-6 z-40 -translate-x-1/2 rounded-full bg-black/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.32em] text-white/90"
-  >
-    Animação começa em {{ previewCountdown() }}s
+  <div class="pointer-events-none fixed inset-0 z-40 flex items-center justify-center">
+    <div
+      class="rounded-full border px-6 py-3 text-xs font-semibold uppercase tracking-[0.32em] backdrop-blur-md transition-colors duration-300"
+      [ngClass]="themeService.isDark()
+        ? 'bg-black/80 text-white/90 border-white/10 shadow-[0_30px_90px_rgba(0,0,0,0.55)]'
+        : 'bg-white/85 text-slate-900/90 border-slate-200/80 shadow-[0_30px_90px_rgba(15,23,42,0.18)]'"
+    >
+      Animação começa em {{ previewCountdown() }}s
+    </div>
   </div>
 }
 


### PR DESCRIPTION
## Resumo
- impede que o modo idle elíptico seja acionado durante a contagem regressiva ou execução da pré-visualização das galerias
- reinicia o temporizador de inatividade ao parar a pré-visualização para que o comportamento normal retorne
- centraliza e aplica o tema atual ao contador exibido durante a contagem regressiva da animação

## Testes
- npm run lint *(falhou: script ausente no projeto)*
- npm run typecheck *(falhou: script ausente no projeto)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69148b9966c883218335c2e538c5f4bf)