### PR TITLE
Ajusta navegação automática e prévia das galerias

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -336,7 +336,7 @@
   }
 </div>
 
-@if (previewCountdown() !== null) {
+@if (autoNavigationCountdown() !== null) {
   <div class="pointer-events-none fixed inset-0 z-40 flex items-center justify-center">
     <div
       class="rounded-full border px-6 py-3 text-xs font-semibold uppercase tracking-[0.32em] backdrop-blur-md transition-colors duration-300"
@@ -344,16 +344,16 @@
         ? 'bg-black/80 text-white/90 border-white/10 shadow-[0_30px_90px_rgba(0,0,0,0.55)]'
         : 'bg-white/85 text-slate-900/90 border-slate-200/80 shadow-[0_30px_90px_rgba(15,23,42,0.18)]'"
     >
-      Animação começa em {{ previewCountdown() }}s
+      Navegação automática começa em {{ autoNavigationCountdown() }}s
     </div>
   </div>
 }
 
-@if (isPreviewPlaying() && previewCountdown() === null) {
+@if (isAutoNavigationActive() && autoNavigationCountdown() === null) {
   <div
     class="pointer-events-none fixed left-1/2 top-20 z-30 -translate-x-1/2 rounded-full bg-black/60 px-4 py-2 text-xs font-medium uppercase tracking-[0.28em] text-white/80"
   >
-    Animação em andamento — pressione P para parar
+    Navegação automática em andamento — pressione P para parar
   </div>
 }
 
@@ -366,13 +366,13 @@
     [groups]="contextMenu().groups"
     [themePalette]="themeService.contextMenuPalette()"
     [themeMode]="themeService.theme()"
-    [isPreviewPlaying]="isPreviewPlaying()"
-    [previewCountdown]="previewCountdown()"
+    [isAutoNavigationActive]="isAutoNavigationActive()"
+    [autoNavigationCountdown]="autoNavigationCountdown()"
     (close)="closeContextMenu()"
     (capture)="openWebcamCapture()"
     (toggleFullscreen)="toggleFullscreen()"
     (toggleTheme)="toggleThemeMode()"
-    (togglePlayback)="togglePreviewPlayback()"
+    (togglePlayback)="toggleAutoNavigation()"
     (createGallery)="openGalleryCreationDialog()"
     (editGallery)="editGalleryContextMenu()"
     (deleteGallery)="deleteGalleryContextMenu()"

--- a/src/components/context-menu/context-menu.component.ts
+++ b/src/components/context-menu/context-menu.component.ts
@@ -46,7 +46,7 @@ import { ContextMenuPalette, ThemeMode } from '../../services/theme.service';
                       <span>{{ themeMode() === 'dark' ? 'Ativar modo claro' : 'Ativar modo escuro' }}</span>
                     </ng-container>
                     <ng-container *ngSwitchCase="'togglePlayback'">
-                      @if (isPreviewPlaying()) {
+                      @if (isAutoNavigationActive()) {
                         <svg
                           xmlns="http://www.w3.org/2000/svg"
                           class="h-4 w-4"
@@ -58,7 +58,7 @@ import { ContextMenuPalette, ThemeMode } from '../../services/theme.service';
                         >
                           <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 6h-3A1.5 1.5 0 0 0 6 7.5v9A1.5 1.5 0 0 0 7.5 18h3A1.5 1.5 0 0 0 12 16.5v-9A1.5 1.5 0 0 0 10.5 6Zm7.5 1.5v9A1.5 1.5 0 0 1 16.5 18h-3a1.5 1.5 0 0 1-1.5-1.5v-9A1.5 1.5 0 0 1 13.5 6h3A1.5 1.5 0 0 1 18 7.5Z" />
                         </svg>
-                        <span>Parar animação</span>
+                        <span>Parar navegação automática</span>
                       } @else {
                         <svg
                           xmlns="http://www.w3.org/2000/svg"
@@ -70,10 +70,10 @@ import { ContextMenuPalette, ThemeMode } from '../../services/theme.service';
                           <path d="M5.25 5.653c0-1.44 1.585-2.294 2.8-1.509l8.087 5.094a1.8 1.8 0 0 1 0 3.024L8.05 17.357c-1.215.785-2.8-.07-2.8-1.51V5.653Z" />
                         </svg>
                         <span>
-                          @if (previewCountdown() !== null) {
-                            Iniciar animação ({{ previewCountdown() }}s)
+                          @if (autoNavigationCountdown() !== null) {
+                            Iniciar navegação automática ({{ autoNavigationCountdown() }}s)
                           } @else {
-                            Iniciar animação
+                            Iniciar navegação automática
                           }
                         </span>
                       }
@@ -157,8 +157,8 @@ export class ContextMenuComponent {
   groups = input.required<ContextMenuGroup[]>();
   themePalette = input.required<ContextMenuPalette>();
   themeMode = input.required<ThemeMode>();
-  isPreviewPlaying = input<boolean>(false);
-  previewCountdown = input<number | null>(null);
+  isAutoNavigationActive = input<boolean>(false);
+  autoNavigationCountdown = input<number | null>(null);
 
   hoveredAction = signal<ContextMenuAction | null>(null);
 


### PR DESCRIPTION
## Summary
- substitui o slideshow global acionado pela tecla P por uma navegação automática em elipse integrada ao modo ocioso
- inicia o slideshow das galerias apenas durante o hover, controlando temporizadores e limpeza de imagens prévias
- atualiza textos e bindings do menu de contexto e overlays para refletir o novo comportamento de navegação automática

## Testing
- npm run lint *(falhou: script ausente)*
- npm run typecheck *(falhou: script ausente)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69149c8f8f8083219cc57db59c3e6899)