### PR TITLE
Restaura ocultação do cursor na navegação automática

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -1,7 +1,7 @@
 <!-- Container principal da galeria com listeners para interação -->
 <div
   class="relative h-full w-full overflow-hidden select-none grayscale transition-colors duration-500"
-  [class.cursor-none]="isIdle()"
+  [class.cursor-none]="isIdle() || isAutoNavigationActive()"
   [class.bg-black]="themeService.isDark()"
   [class.bg-slate-100]="themeService.isLight()"
   [class.p-8]="!isMobileLayout()"
@@ -336,24 +336,26 @@
   }
 </div>
 
-@if (autoNavigationCountdown() !== null) {
-  <div class="pointer-events-none fixed inset-0 z-40 flex items-center justify-center">
+@if (autoNavigationOverlayVisible()) {
+  <div class="pointer-events-none fixed inset-0 z-40 flex items-center justify-center px-4">
     <div
-      class="rounded-full border px-6 py-3 text-xs font-semibold uppercase tracking-[0.32em] backdrop-blur-md transition-colors duration-300"
+      class="pointer-events-auto w-full max-w-xl rounded-3xl border px-8 py-6 text-center backdrop-blur-md transition-colors duration-300"
       [ngClass]="themeService.isDark()
         ? 'bg-black/80 text-white/90 border-white/10 shadow-[0_30px_90px_rgba(0,0,0,0.55)]'
         : 'bg-white/85 text-slate-900/90 border-slate-200/80 shadow-[0_30px_90px_rgba(15,23,42,0.18)]'"
     >
-      Navegação automática começa em {{ autoNavigationCountdown() }}s
+      @if (autoNavigationCountdown() !== null) {
+        <p class="text-[11px] font-semibold uppercase tracking-[0.32em] opacity-80">
+          Navegação automática começa em
+        </p>
+        <p class="mt-3 text-4xl font-bold tracking-[0.4em]">
+          {{ autoNavigationCountdown() }}s
+        </p>
+      }
+      <p class="mt-4 text-sm font-medium leading-relaxed opacity-90">
+        Pressione <span class="font-semibold">P</span> ou use o menu de contexto (botão direito) para parar a navegação automática.
+      </p>
     </div>
-  </div>
-}
-
-@if (isAutoNavigationActive() && autoNavigationCountdown() === null) {
-  <div
-    class="pointer-events-none fixed left-1/2 top-20 z-30 -translate-x-1/2 rounded-full bg-black/60 px-4 py-2 text-xs font-medium uppercase tracking-[0.28em] text-white/80"
-  >
-    Navegação automática em andamento — pressione P para parar
   </div>
 }
 


### PR DESCRIPTION
## Resumo
- oculta o cursor e desativa hovers enquanto a navegação automática está em execução
- impede a reprodução automática das prévias de galerias durante o modo automático
- combina o contador e o aviso centralizado, exibindo a instrução por alguns segundos após o início do modo automático

## Testes
- `npm run lint` *(falhou: script ausente)*
- `npm run typecheck` *(falhou: script ausente)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914a2acff9c8321b61dc6434ff37fad)