### PR TITLE
Fix auto navigation idle detection

### DIFF
--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -1197,7 +1197,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     this.ngZone.runOutsideAngular(() => {
       const animate = () => {
         if (!this.isMobileLayout()) {
-          if (this.isIdle()) {
+          if (this.isAutoNavigationActive()) {
             // Atualiza o ângulo para percorrer a elipse
             this.idleEllipseAngle += this.idleSpeed;
 
@@ -1217,7 +1217,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
             }
           }
 
-          const shouldUpdatePosition = this.isIdle() || this.isInteractionEnabled();
+          const shouldUpdatePosition = this.isAutoNavigationActive() || this.isInteractionEnabled();
 
           if (shouldUpdatePosition) {
             this.current.x += (this.target.x - this.current.x) * this.settings.dragEase;


### PR DESCRIPTION
## Summary
- update the animation loop to rely on the auto-navigation flag instead of the idle signal
- keep position updates active whenever auto navigation is running

## Testing
- npm run lint *(fails: Missing script "lint")*
- npm run typecheck *(fails: Missing script "typecheck")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914c6fbd21083219045e05befdce312)