### PR TITLE
Impedir navegação automática por inatividade

### DIFF
--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -466,7 +466,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
 
   // --- Sinais e Propriedades para o Modo Ocioso ---
   isIdle = signal(false);
-  private inactivityTimeoutId: any;
+  private inactivityTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private idleEllipseAngle = 0;
   private idleEllipseCenter = { x: 0, y: 0 };
   private idleEllipseRadiusX = 0; // Semi-eixo maior (horizontal) - será calculado baseado na tela
@@ -682,11 +682,6 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.isAutoNavigationSequenceActive()) {
       return;
     }
-
-    this.inactivityTimeoutId = setTimeout(() => {
-      this.inactivityTimeoutId = null;
-      this.ngZone.run(() => this.activateAutoNavigation());
-    }, 5000);
   }
 
   private configureIdleEllipse(): void {


### PR DESCRIPTION
## Summary
- remove o gatilho de inatividade que ativava a navegação automática
- ajusta a tipagem do temporizador de inatividade para manter o estado consistente

## Testing
- npm run lint *(fails: missing script)*
- npm run typecheck *(fails: missing script)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914e1a8e110832181257237b1a939f3)