### PR TITLE
Desativar interação dos cards durante navegação automática

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -174,13 +174,14 @@
                 [class.rounded-[2.5rem]]="themeService.isLight()"
                 [class.ring-white\/10]="themeService.isDark()"
                 [class.ring-slate-300\/60]="themeService.isLight()"
+                [class.pointer-events-none]="!isInteractionEnabled()"
                 [class.bg-slate-100]="themeService.isLight()"
                 [style.width.px]="item.width"
                 [style.height.px]="item.height"
                 [style.left.px]="item.x"
                 [style.top.px]="item.y"
                 [class.cursor-pointer]="isInteractionEnabled()"
-                data-cursor-pointer
+                [attr.data-cursor-pointer]="isInteractionEnabled() ? '' : null"
                 (click)="selectGallery(item.id)"
                 (mouseenter)="onGalleryHoverStart(item.id, item.previewKey)"
                 (mouseleave)="onGalleryHoverEnd(item.previewKey)"
@@ -250,13 +251,14 @@
             [class.rounded-[2.5rem]]="themeService.isLight()"
             [class.ring-white\/10]="themeService.isDark()"
             [class.ring-slate-300\/60]="themeService.isLight()"
+            [class.pointer-events-none]="!isInteractionEnabled()"
             [class.bg-slate-100]="themeService.isLight()"
             [style.width.px]="item.width"
             [style.height.px]="item.height"
             [style.left.px]="item.x"
             [style.top.px]="item.y"
             [class.cursor-pointer]="isInteractionEnabled()"
-            data-cursor-pointer
+            [attr.data-cursor-pointer]="isInteractionEnabled() ? '' : null"
             (click)="onImageClick($event, item)"
           >
             <div class="item-image-container relative h-full w-full overflow-hidden">


### PR DESCRIPTION
## Summary
- impede interações de mouse nos cards de galeria e foto quando a navegação automática está ativa
- remove o atributo do cursor interativo quando os cards estão desativados para evitar estados inconsistentes

## Testing
- npm run lint *(fails: script ausente no projeto)*
- npm run typecheck *(fails: script ausente no projeto)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914f768ef7c8321b75ab2ec51d834af)