### PR TITLE
Restaurar navegação automática e bloquear interações durante o modo automático

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -180,7 +180,7 @@
                 [style.left.px]="item.x"
                 [style.top.px]="item.y"
                 [class.cursor-pointer]="isInteractionEnabled()"
-                data-cursor-pointer
+                [attr.data-cursor-pointer]="isInteractionEnabled() ? '' : null"
                 (click)="selectGallery(item.id)"
                 (mouseenter)="onGalleryHoverStart(item.id, item.previewKey)"
                 (mouseleave)="onGalleryHoverEnd(item.previewKey)"
@@ -256,7 +256,7 @@
             [style.left.px]="item.x"
             [style.top.px]="item.y"
             [class.cursor-pointer]="isInteractionEnabled()"
-            data-cursor-pointer
+            [attr.data-cursor-pointer]="isInteractionEnabled() ? '' : null"
             (click)="onImageClick($event, item)"
           >
             <div class="item-image-container relative h-full w-full overflow-hidden">
@@ -310,6 +310,14 @@
         </svg>
       </button>
     }
+  }
+
+  @if (isAutoNavigationActive()) {
+    <div
+      class="fixed inset-0 z-30 cursor-default pointer-events-auto"
+      aria-hidden="true"
+      data-auto-navigation-shield
+    ></div>
   }
 
   <!-- Overlay para o modo de visualização expandida -->

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -723,6 +723,10 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private onMouseEnter(): void {
     this.interactionState.isMouseOver = true;
+    if (this.isAutoNavigationActive()) {
+      return;
+    }
+
     this.resetInactivityTimer();
   }
 
@@ -743,6 +747,11 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
 
     this.interactionState.mouseX = clampedX;
     this.interactionState.mouseY = clampedY;
+
+    if (this.isAutoNavigationActive()) {
+      return;
+    }
+
     this.resetInactivityTimer();
   }
 


### PR DESCRIPTION
## Summary
- remove a aplicação direta de `pointer-events: none` nos cards para restaurar o comportamento da navegação automática
- adiciona uma camada transparente que bloqueia cliques enquanto a navegação automática está ativa
- impede que movimentos do mouse encerrem a navegação automática ao ignorar eventos de entrada/movimento durante o modo automático

## Testing
- npm run lint *(fails: script ausente no projeto)*
- npm run typecheck *(fails: script ausente no projeto)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914f768ef7c8321b75ab2ec51d834af)