### PR TITLE
Remove fluxo de funcionamento da janela de apresentação

### DIFF
--- a/src/components/info-dialog/info-dialog.component.ts
+++ b/src/components/info-dialog/info-dialog.component.ts
@@ -60,15 +60,6 @@ import { ThemeService } from '../../services/theme.service';
                 Os dados são armazenados localmente no navegador, garantindo privacidade e acesso
                 rápido às suas galerias.
               </p>
-              <div class="space-y-2 pt-4 border-t" [style.borderColor]="themeService.dialogPalette().border">
-                <h3 class="text-sm font-medium" [style.color]="themeService.dialogPalette().title">Fluxo de funcionamento</h3>
-                <ul class="space-y-2 text-sm">
-                  <li>Abra o painel lateral para criar uma nova galeria e defina nome, descrição e capa.</li>
-                  <li>Dentro de uma galeria, utilize a câmera integrada para capturar novas fotos ou importe arquivos existentes.</li>
-                  <li>Organize as imagens com o menu de contexto: renomeie, exclua ou mova fotos entre galerias.</li>
-                  <li>Ao acessar uma foto, utilize o modo expandido para analisar detalhes e aplicar efeitos.</li>
-                </ul>
-              </div>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- remove o bloco de texto sobre fluxo de funcionamento da janela de apresentação do aplicativo

## Testing
- npm run lint *(falha: Missing script "lint")*
- npm run typecheck *(falha: Missing script "typecheck")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915d59f26cc83219498e3d7840e814d)