### PR TITLE
feat: simplify mobile capture experience

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -10,133 +10,210 @@
   @if (isMobileLayout()) {
     <div class="flex h-full flex-col bg-black text-white">
       @if (currentView() === 'galleries') {
-        @if (galleryService.galleries().length === 0) {
-          <div class="flex flex-1 flex-col items-center justify-center gap-4 px-6 text-center text-gray-300">
-            <svg class="h-10 w-10 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="0.5" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
-            </svg>
-            <h2 class="text-lg font-medium">Nenhuma galeria criada</h2>
-            <p class="text-sm text-gray-400">Toque em adicionar para começar uma nova história.</p>
-          </div>
-        } @else {
-          <div
-            #mobileScrollContainer
-            class="flex-1 overflow-y-auto snap-y snap-mandatory scroll-smooth space-y-6 px-6 py-8"
-            (scroll)="onMobileScroll()"
-          >
-            @for (gallery of mobileInfiniteGalleries(); track trackMobileGalleryLoop($index, gallery)) {
-              <button
-                type="button"
-                data-cursor-pointer
-                class="group block w-full snap-start"
-                (click)="selectGallery(gallery.id)"
-              >
-                <div class="relative aspect-square w-full overflow-hidden rounded-[2.5rem]">
+        <div #mobileScrollContainer class="flex-1 overflow-y-auto">
+          <div class="flex flex-col gap-6 px-6 pb-20 pt-12">
+            <header class="space-y-4">
+              <div class="flex items-start justify-between gap-4">
+                <div class="space-y-1">
+                  <p class="text-xs uppercase tracking-[0.35em] text-gray-500">Diário visual</p>
+                  <h1 class="text-2xl font-semibold leading-tight text-white">Captura instantânea</h1>
+                  <p class="text-sm text-gray-400">Um toque para registrar, outro para guardar.</p>
+                </div>
+                <button
+                  type="button"
+                  data-cursor-pointer
+                  class="rounded-full bg-white px-4 py-2 text-sm font-semibold text-black shadow-lg shadow-white/20 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-white/60"
+                  (click)="startQuickCapture()">
+                  Capturar
+                </button>
+              </div>
+              @if (lastCapturedImage()) {
+                <div class="overflow-hidden rounded-3xl border border-white/10">
                   <img
-                    [src]="getGalleryCover(gallery)"
-                    loading="lazy"
-                    class="absolute inset-0 h-full w-full object-cover"
-                    alt="Galeria {{ gallery.name }}"
-                  >
-                  <div class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black via-black/60 to-transparent p-8 text-left">
-                    @if (gallery.createdAt) {
-                      <p class="text-xs uppercase tracking-[0.4em] text-gray-300">{{ gallery.createdAt }}</p>
-                    }
-                    <h2 class="mt-4 text-2xl font-semibold leading-tight">{{ gallery.name }}</h2>
-                    @if (gallery.description) {
-                      <p class="mt-3 max-w-[28ch] text-sm text-gray-200">{{ gallery.description }}</p>
-                    }
-                    <p class="mt-6 text-xs uppercase tracking-[0.6em] text-gray-400">{{ gallery.imageUrls.length }} fotos</p>
+                    [src]="lastCapturedImage()!"
+                    alt="Última captura registrada"
+                    class="h-48 w-full object-cover">
+                  <div class="flex items-center justify-between bg-black/70 px-4 py-3 text-xs font-medium tracking-wide text-gray-200">
+                    <span>Última captura</span>
+                    <span
+                      class="uppercase"
+                      [class.text-emerald-300]="!isLastCapturePending()"
+                      [class.text-amber-300]="isLastCapturePending()">
+                      {{ isLastCapturePending() ? 'aguardando envio' : 'registrada' }}
+                    </span>
                   </div>
                 </div>
-              </button>
+              }
+            </header>
+
+            @if (pendingCaptures().length > 0) {
+              <section class="rounded-3xl border border-white/10 bg-white/5 p-4">
+                <div class="flex items-center justify-between text-sm font-medium text-gray-200">
+                  <span>Capturas guardadas</span>
+                  <span class="text-xs text-gray-400">{{ pendingCaptures().length }} aguardando</span>
+                </div>
+                <p class="mt-2 text-xs text-gray-400">
+                  Escolha uma galeria para enviar ou descarte o que não for necessário.
+                </p>
+                <div class="mt-4 grid grid-cols-2 gap-3">
+                  @for (capture of pendingCaptures(); track trackPendingCapture($index, capture)) {
+                    <div class="flex flex-col gap-2 rounded-2xl bg-black/50 p-3">
+                      <div class="relative overflow-hidden rounded-xl border border-white/10">
+                        <img
+                          [src]="capture"
+                          alt="Captura pendente"
+                          class="h-28 w-full object-cover">
+                      </div>
+                      <select
+                        class="w-full rounded-xl border border-white/20 bg-black/40 px-3 py-2 text-xs text-gray-200 focus:border-white focus:outline-none"
+                        (change)="onPendingGallerySelect($event, capture)">
+                        <option value="">Enviar para...</option>
+                        @for (gallery of galleries(); track gallery.id) {
+                          <option [value]="gallery.id">{{ gallery.name }}</option>
+                        }
+                      </select>
+                      <button
+                        type="button"
+                        data-cursor-pointer
+                        class="rounded-xl border border-red-400/40 bg-red-500/10 px-3 py-2 text-xs font-medium text-red-200 transition hover:bg-red-500/20 focus:outline-none focus:ring-2 focus:ring-red-400/40"
+                        (click)="discardPendingCapture(capture)">
+                        Descartar
+                      </button>
+                    </div>
+                  }
+                </div>
+              </section>
             }
+
+            <section class="space-y-4 pb-8">
+              <div class="flex items-center justify-between">
+                <h2 class="text-xs uppercase tracking-[0.3em] text-gray-500">Galerias</h2>
+                <button
+                  type="button"
+                  data-cursor-pointer
+                  class="rounded-full border border-white/20 px-4 py-2 text-xs font-semibold text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
+                  (click)="openGalleryCreationDialog()">
+                  Nova galeria
+                </button>
+              </div>
+
+              @if (galleries().length === 0) {
+                <div class="flex flex-col items-center justify-center gap-3 rounded-3xl border border-dashed border-white/20 bg-black/40 px-6 py-14 text-center text-gray-300">
+                  <svg class="h-10 w-10 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="0.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
+                  </svg>
+                  <h3 class="text-lg font-medium text-white">Nenhuma galeria ainda</h3>
+                  <p class="text-sm text-gray-400">Crie uma galeria ou comece capturando para salvar depois.</p>
+                </div>
+              } @else {
+                <div class="space-y-3">
+                  @for (gallery of galleries(); track gallery.id) {
+                    <div class="rounded-3xl border border-white/10 bg-black/50 p-4">
+                      <div class="flex items-start justify-between gap-4">
+                        <div class="space-y-1">
+                          @if (gallery.createdAt) {
+                            <p class="text-[10px] uppercase tracking-[0.4em] text-gray-500">{{ gallery.createdAt }}</p>
+                          }
+                          <h3 class="text-lg font-semibold text-white">{{ gallery.name }}</h3>
+                          <p class="text-xs text-gray-400">{{ gallery.imageUrls.length }} fotos</p>
+                        </div>
+                        <div class="flex flex-col gap-2 text-xs font-semibold">
+                          <button
+                            type="button"
+                            data-cursor-pointer
+                            class="rounded-full bg-white px-4 py-2 text-black transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-white/60"
+                            (click)="startCaptureForGallery(gallery.id)">
+                            Capturar
+                          </button>
+                          @if (selectedPendingCapture()) {
+                            <button
+                              type="button"
+                              data-cursor-pointer
+                              class="rounded-full border border-white/20 px-4 py-2 text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
+                              (click)="assignPendingToGallery(gallery.id)">
+                              Enviar captura
+                            </button>
+                          }
+                        </div>
+                      </div>
+                      <div class="mt-4 flex flex-wrap items-center gap-3 text-xs text-gray-400">
+                        <button
+                          type="button"
+                          data-cursor-pointer
+                          class="rounded-full border border-white/20 px-3 py-1 text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
+                          (click)="viewGallery(gallery.id)">
+                          Ver fotos
+                        </button>
+                        <button
+                          type="button"
+                          data-cursor-pointer
+                          class="rounded-full border border-red-500/40 px-3 py-1 text-red-200 transition hover:bg-red-500/20 focus:outline-none focus:ring-2 focus:ring-red-400/40"
+                          (click)="deleteGallery(gallery.id)">
+                          Excluir
+                        </button>
+                      </div>
+                    </div>
+                  }
+                </div>
+              }
+            </section>
           </div>
-        }
+        </div>
       } @else {
-        <div
-          #mobileScrollContainer
-          class="flex-1 overflow-y-auto bg-black"
-          (scroll)="onMobileScroll()"
-        >
-          <div class="px-4 pb-40 pt-6">
+        <div class="flex h-full flex-col bg-black">
+          <header class="flex items-center justify-between px-4 pb-4 pt-6">
+            <button
+              type="button"
+              data-cursor-pointer
+              class="rounded-full border border-white/20 px-3 py-1 text-xs font-semibold text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
+              (click)="backToGalleries()">
+              Galerias
+            </button>
+            <div class="text-center text-xs text-gray-400">
+              @if (activeGallery()) {
+                <p class="uppercase tracking-[0.3em] text-gray-500">{{ activeGallery()!.createdAt }}</p>
+                <p class="mt-1 text-sm font-semibold text-white">{{ activeGallery()!.name }}</p>
+                <p class="mt-1 text-xs text-gray-400">{{ images().length }} fotos</p>
+              } @else {
+                <p class="text-sm font-semibold text-white">Galeria</p>
+              }
+            </div>
+            <button
+              type="button"
+              data-cursor-pointer
+              class="rounded-full bg-white px-3 py-2 text-xs font-semibold text-black transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-white/60 disabled:cursor-not-allowed disabled:bg-white/40 disabled:text-black/60"
+              [disabled]="!activeGallery()"
+              (click)="activeGallery() && startCaptureForGallery(activeGallery()!.id)">
+              Capturar
+            </button>
+          </header>
+          <div class="flex-1 overflow-y-auto px-4 pb-20">
             @if (images().length === 0) {
               <div class="flex min-h-[60vh] flex-col items-center justify-center gap-3 text-center text-gray-300">
                 <svg class="h-10 w-10 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="0.5" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
                 </svg>
                 <h2 class="text-lg font-medium">Esta galeria está vazia</h2>
-                <p class="text-sm text-gray-400">Toque em adicionar para trazer novas imagens.</p>
+                <p class="text-sm text-gray-400">Capture novas imagens para começar seu diário.</p>
               </div>
             } @else {
-              <div class="grid grid-cols-3 gap-3">
+              <div class="grid grid-cols-3 gap-3 pb-10">
                 @for (image of images(); track trackMobileImage($index, image); let index = $index) {
                   <button
                     type="button"
                     data-cursor-pointer
                     class="group relative aspect-square overflow-hidden rounded-3xl bg-zinc-900/60"
-                    (click)="onMobilePhotoClick($event, image, index)"
-                  >
+                    (click)="onMobilePhotoClick($event, image, index)">
                     <img
                       [src]="image"
                       loading="lazy"
                       class="h-full w-full object-cover transition-transform duration-500 group-active:scale-95 group-hover:scale-[1.03]"
-                      alt="Imagem da galeria"
-                    >
+                      alt="Imagem da galeria">
                     <span class="pointer-events-none absolute inset-0 border border-white/10 mix-blend-screen"></span>
                   </button>
                 }
               </div>
             }
-          </div>
-        </div>
-      }
-
-      @if (
-        mobileCommandPanelVisible() &&
-        !expandedItem() &&
-        !isWebcamVisible() &&
-        !isGalleryEditorVisible() &&
-        !isGalleryCreationDialogVisible() &&
-        !isInfoDialogVisible()
-      ) {
-        <div class="pointer-events-none fixed inset-x-0 bottom-0 z-40 px-6 pb-[calc(env(safe-area-inset-bottom,0)+1.5rem)]">
-          <div class="pointer-events-auto flex items-center gap-4 rounded-full bg-black/60 px-6 py-4 shadow-lg shadow-black/40 backdrop-blur-md">
-            @if (currentView() === 'photos') {
-              <button
-                type="button"
-                data-cursor-pointer
-                class="flex items-center gap-2 rounded-full px-3 py-2 text-sm font-medium text-white/90 transition hover:text-white"
-                (click)="backToGalleries()"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
-                </svg>
-                Voltar
-              </button>
-            }
-            <button
-              type="button"
-              data-cursor-pointer
-              class="flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/20"
-              (click)="mobileAddAction()"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-              </svg>
-              Adicionar
-            </button>
-            <button
-              type="button"
-              data-cursor-pointer
-              class="flex items-center gap-2 rounded-full px-3 py-2 text-sm font-medium text-white/90 transition hover:text-white"
-              (click)="toggleInfoDialog()"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M12 18h.008v.008H12V18Zm-.25-3.75h.5a.75.75 0 0 0 .75-.75V9.75A.75.75 0 0 0 12.25 9h-.5a.75.75 0 0 0-.75.75v3.75a.75.75 0 0 0 .75.75Zm.25-9a9 9 0 1 0 9 9 9.01 9.01 0 0 0-9-9Z" />
-              </svg>
-              Ajuda
-            </button>
           </div>
         </div>
       }
@@ -394,7 +471,9 @@
 
 @if (isWebcamVisible()) {
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75" (click)="isWebcamVisible.set(false)" data-cursor-pointer>
-    <app-webcam-capture (close)="isWebcamVisible.set(false)"></app-webcam-capture>
+    <app-webcam-capture
+      (capture)="onCaptureComplete($event)"
+      (close)="isWebcamVisible.set(false)"></app-webcam-capture>
   </div>
 }
 

--- a/src/components/webcam-capture/webcam-capture.component.ts
+++ b/src/components/webcam-capture/webcam-capture.component.ts
@@ -1,6 +1,5 @@
 import { Component, ChangeDetectionStrategy, output, inject, signal, viewChild, ElementRef, AfterViewInit, OnDestroy, HostListener, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { GalleryService } from '../../services/gallery.service';
 import { ThemeService } from '../../services/theme.service';
 
 @Component({
@@ -180,6 +179,7 @@ export class WebcamCaptureComponent implements AfterViewInit, OnDestroy {
   }
 
   close = output<void>();
+  capture = output<string>();
   isStreaming = signal(false);
   error = signal<string | null>(null);
   isTimerEnabled = signal(false);
@@ -193,7 +193,6 @@ export class WebcamCaptureComponent implements AfterViewInit, OnDestroy {
   videoElement = viewChild.required<ElementRef<HTMLVideoElement>>('videoElement');
   canvasElement = viewChild.required<ElementRef<HTMLCanvasElement>>('canvasElement');
 
-  private galleryService = inject(GalleryService);
   themeService = inject(ThemeService);
   private stream: MediaStream | null = null;
   private countdownIntervalId: any;
@@ -361,7 +360,7 @@ export class WebcamCaptureComponent implements AfterViewInit, OnDestroy {
 
       // Get the processed image URL
       const dataUrl = canvas.toDataURL('image/png');
-      this.galleryService.addImage(dataUrl);
+      this.capture.emit(dataUrl);
       this.close.emit();
     } else {
       this.error.set('Não foi possível capturar a imagem.');


### PR DESCRIPTION
## Summary
- reimagine the mobile galleries screen with quick capture actions, pending queue management, and simplified navigation
- persist unassigned captures in the gallery service and allow routing them into galleries when ready
- emit captured frames from the webcam component so the root component can decide whether to store or queue them

## Testing
- npm run lint *(fails: script not found)*
- npm run typecheck *(fails: script not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915d5f3f9e08321a449701e08b2b5ee)