### PR TITLE
Remove o cabeçalho da captura móvel

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -11,19 +11,7 @@
     @switch (mobileView()) {
       @case ('capture') {
         <div class="flex min-h-screen flex-col bg-black text-white">
-          <header class="flex items-center justify-between px-6 pt-8 pb-4">
-            <div>
-              <p class="text-[10px] uppercase tracking-[0.38em] text-gray-500">Diário visual</p>
-              <h1 class="mt-1 text-xl font-semibold">Captura em foco</h1>
-            </div>
-            <button
-              type="button"
-              class="rounded-full border border-white/20 px-4 py-2 text-xs font-semibold text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
-              (click)="showMobileGalleries()">
-              Galerias
-            </button>
-          </header>
-          <div class="flex-1 px-6">
+          <div class="flex-1 px-6 pt-8">
             <app-webcam-capture
               [variant]="'mobile'"
               [captureAllowed]="!!mobileCaptureGallery()"


### PR DESCRIPTION
## Summary
- remove o cabeçalho do fluxo de captura móvel no layout responsivo
- ajusta o espaçamento superior do conteúdo principal após a remoção do cabeçalho

## Testing
- npm run lint *(falhou: Missing script: "lint")*
- npm run typecheck *(falhou: Missing script: "typecheck")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691615e825708321ad5bb059da89884c)