### PR TITLE
Remover painel de capturas guardadas na visão mobile

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -49,23 +49,6 @@
                 </div>
               </div>
             }
-            <div class="rounded-3xl border border-white/10 bg-white/5 px-5 py-4 text-sm text-gray-200">
-              <div class="flex items-center justify-between">
-                <span>Capturas guardadas</span>
-                <span class="text-xs text-gray-400">{{ pendingCaptures().length }} itens</span>
-              </div>
-              <p class="mt-2 text-xs text-gray-400">
-                Toque para organizar capturas e enviar para uma galeria.
-              </p>
-              <button
-                type="button"
-                class="mt-4 w-full rounded-full bg-white px-4 py-2 text-xs font-semibold text-black transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-white/50"
-                (click)="showMobileGalleries()"
-                [disabled]="pendingCaptures().length === 0"
-                [class.opacity-60]="pendingCaptures().length === 0">
-                Gerenciar capturas
-              </button>
-            </div>
           </div>
         </div>
       }

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -1081,12 +1081,6 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     this.handleMobileNavigationTransition();
   }
 
-  showMobileGalleries(): void {
-    this.currentView.set('galleries');
-    this.mobileView.set('galleries');
-    this.handleMobileNavigationTransition();
-  }
-
   openMobileGalleryDetail(galleryId: string): void {
     this.selectGallery(galleryId);
     this.mobileView.set('galleryDetail');


### PR DESCRIPTION
## Summary
- remove o card de "Capturas guardadas" da tela de captura no layout mobile
- elimina o método `showMobileGalleries` que passou a ficar sem uso

## Testing
- npm run lint *(falhou: Missing script "lint")*
- npm run typecheck *(falhou: Missing script "typecheck")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691617f80b6c8321abe5c230f7f4d7fe)