### PR TITLE
Remover fluxo de captura sem galeria

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -228,12 +228,6 @@
               (click)="openGalleryCreationDialogForMobileCapture()">
               Criar nova galeria
             </button>
-            <button
-              type="button"
-              class="rounded-2xl border border-white/15 bg-transparent px-4 py-3 text-sm font-semibold text-gray-300 transition hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-white/20"
-              (click)="clearMobileCaptureGallery()">
-              Captura rápida (sem galeria)
-            </button>
           </div>
         </div>
       </div>

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -489,7 +489,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly MOBILE_BREAKPOINT = 768;
   isMobileLayout = signal(false);
   mobileCommandPanelVisible = signal(false);
-  captureMode = signal<'selected' | 'unassigned'>('selected');
+  captureMode = signal<'selected'>('selected');
   pendingCaptures = computed(() => this.galleryService.pendingCaptures());
   lastCapturedImage = signal<string | null>(null);
   pendingCaptureToAssign = signal<string | null>(null);
@@ -1044,18 +1044,6 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-  startQuickCapture(): void {
-    if (this.isMobileLayout()) {
-      this.mobileCaptureGalleryId.set(null);
-      this.captureMode.set('unassigned');
-      this.showMobileCapture();
-      return;
-    }
-
-    this.galleryService.selectGallery(null);
-    this.openWebcamCapture('unassigned');
-  }
-
   startCaptureForGallery(galleryId: string): void {
     if (this.isMobileLayout()) {
       this.showCaptureWithGallery(galleryId);
@@ -1063,7 +1051,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     }
 
     this.galleryService.selectGallery(galleryId);
-    this.openWebcamCapture('selected');
+    this.openWebcamCapture();
   }
 
   viewGallery(galleryId: string): void {
@@ -1116,20 +1104,14 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     this.closeMobileGalleryPicker();
   }
 
-  clearMobileCaptureGallery(): void {
-    this.mobileCaptureGalleryId.set(null);
-    this.closeMobileGalleryPicker();
-  }
-
   prepareMobileCapture(): void {
     const captureId = this.mobileCaptureGalleryId();
-    if (captureId) {
-      this.galleryService.selectGallery(captureId);
-      this.captureMode.set('selected');
-    } else {
-      this.galleryService.selectGallery(null);
-      this.captureMode.set('unassigned');
+    if (!captureId) {
+      return;
     }
+
+    this.galleryService.selectGallery(captureId);
+    this.captureMode.set('selected');
   }
 
   openGalleryCreationDialogForMobileCapture(): void {
@@ -1627,22 +1609,18 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     this.contextMenuGalleryId = null;
   }
 
-  openWebcamCapture(mode: 'selected' | 'unassigned' = 'selected'): void {
+  openWebcamCapture(): void {
     if (this.isMobileLayout()) {
-      this.captureMode.set(mode);
-      if (mode === 'selected') {
-        const selectedId = this.galleryService.selectedGalleryId();
-        if (selectedId) {
-          this.mobileCaptureGalleryId.set(selectedId);
-        }
-      } else {
-        this.mobileCaptureGalleryId.set(null);
+      this.captureMode.set('selected');
+      const selectedId = this.galleryService.selectedGalleryId();
+      if (selectedId) {
+        this.mobileCaptureGalleryId.set(selectedId);
       }
       this.showMobileCapture();
       return;
     }
 
-    this.captureMode.set(mode);
+    this.captureMode.set('selected');
     this.deactivateAutoNavigation(true);
     this.isWebcamVisible.set(true);
   }


### PR DESCRIPTION
## Summary
- remove o atalho de "captura rápida" do seletor de galerias no mobile
- ajusta o componente raiz para sempre exigir uma galeria selecionada antes da captura de fotos

## Testing
- npm run lint *(fails: Missing script: "lint")*
- npm run typecheck *(fails: Missing script: "typecheck")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69162089a19c8321ae608c6da708edf4)