### PR TITLE
Reorganizar seleção de galeria na captura mobile

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -11,44 +11,28 @@
     @switch (mobileView()) {
       @case ('capture') {
         <div class="flex min-h-screen flex-col bg-black text-white">
-          <div class="flex-1 px-6 pt-8">
+          <div class="flex-1 px-6 pt-8 pb-10">
             <app-webcam-capture
               [variant]="'mobile'"
               [captureAllowed]="!!mobileCaptureGallery()"
               (prepareCapture)="prepareMobileCapture()"
               (capture)="onCaptureComplete($event)">
             </app-webcam-capture>
-          </div>
-          <div class="space-y-5 px-6 pb-10">
-            <button
-              type="button"
-              class="w-full rounded-full border border-white/15 bg-white/5 px-5 py-3 text-left transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30"
-              (click)="openMobileGalleryPicker()">
-              <span class="block text-[11px] uppercase tracking-[0.32em] text-gray-500">Galeria alvo</span>
-              <span class="mt-1 block truncate text-sm font-semibold text-white">
-                @if (mobileCaptureGallery()) {
-                  {{ mobileCaptureGallery()!.name }}
-                } @else {
-                  Selecionar galeria
-                }
-              </span>
-            </button>
-            @if (lastCapturedImage()) {
-              <div class="overflow-hidden rounded-3xl border border-white/10">
-                <img
-                  [src]="lastCapturedImage()!"
-                  alt="Última captura registrada"
-                  class="h-48 w-full object-cover">
-                <div class="flex items-center justify-between bg-black/70 px-4 py-3 text-[11px] font-medium uppercase tracking-[0.3em] text-gray-200">
-                  <span>Última captura</span>
-                  <span
-                    [class.text-emerald-300]="!isLastCapturePending()"
-                    [class.text-amber-300]="isLastCapturePending()">
-                    {{ isLastCapturePending() ? 'aguardando envio' : 'registrada' }}
-                  </span>
-                </div>
-              </div>
-            }
+            <div class="mt-6">
+              <button
+                type="button"
+                class="w-full rounded-full border border-white/15 bg-white/5 px-5 py-3 text-left transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30"
+                (click)="openMobileGalleryPicker()">
+                <span class="block text-[11px] uppercase tracking-[0.32em] text-gray-500">Galeria alvo</span>
+                <span class="mt-1 block truncate text-sm font-semibold text-white">
+                  @if (mobileCaptureGallery()) {
+                    {{ mobileCaptureGallery()!.name }}
+                  } @else {
+                    Selecionar galeria
+                  }
+                </span>
+              </button>
+            </div>
           </div>
         </div>
       }


### PR DESCRIPTION
## Summary
- remove a visualização da última captura na experiência mobile
- reposiciona o seletor de galeria imediatamente abaixo do componente de captura

## Testing
- npm run lint *(falhou: script ausente)*
- npm run typecheck *(falhou: script ausente)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916296325d88321b388559a32bdc2a6)