### PR TITLE
feat: ajustar experiência mobile de galerias

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -38,7 +38,7 @@
       }
       @case ('galleries') {
         <div class="flex min-h-screen flex-col bg-black text-white">
-          <header class="flex items-center justify-between px-6 pt-8 pb-4 text-xs uppercase tracking-[0.32em] text-gray-500">
+          <header class="flex items-center justify-between gap-4 px-6 pt-8 pb-4 text-xs uppercase tracking-[0.32em] text-gray-500">
             <button
               type="button"
               class="rounded-full border border-white/20 px-4 py-2 text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
@@ -49,75 +49,60 @@
             <button
               type="button"
               class="rounded-full border border-white/20 px-4 py-2 text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
-              (click)="openGalleryCreationDialog()">
+              (click)="openGalleryCreationDialogForMobileCapture()">
               Nova
             </button>
           </header>
           <div #mobileScrollContainer class="flex-1 overflow-y-auto px-6 pb-16">
-            <div class="space-y-5">
-              <div class="text-[11px] uppercase tracking-[0.38em] text-gray-500">Galerias</div>
-              @if (galleries().length === 0) {
-                <div class="flex flex-col items-center justify-center gap-3 rounded-3xl border border-dashed border-white/20 bg-white/5 px-6 py-16 text-center text-gray-300">
-                  <svg class="h-10 w-10 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="0.5" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
-                  </svg>
-                  <h3 class="text-lg font-medium">Nenhuma galeria ainda</h3>
-                  <p class="text-sm text-gray-400">Crie uma galeria para começar ou capture e salve depois.</p>
-                </div>
-              } @else {
-                <div class="space-y-4">
-                  @for (gallery of galleries(); track gallery.id) {
-                    <div class="rounded-3xl border border-white/10 bg-white/5 p-4">
-                      <div class="flex items-start justify-between gap-4">
-                        <div class="space-y-1">
-                          @if (gallery.createdAt) {
-                            <p class="text-[10px] uppercase tracking-[0.38em] text-gray-500">{{ gallery.createdAt }}</p>
-                          }
-                          <h3 class="text-lg font-semibold text-white">{{ gallery.name }}</h3>
-                          <p class="text-xs text-gray-400">{{ gallery.imageUrls.length }} fotos</p>
-                        </div>
-                        <div class="flex flex-col gap-2 text-xs font-semibold">
-                          <button
-                            type="button"
-                            class="rounded-full bg-white px-4 py-2 text-black transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-white/60"
-                            (click)="showCaptureWithGallery(gallery.id)">
-                            Capturar
-                          </button>
-                          <button
-                            type="button"
-                            class="rounded-full border border-white/20 px-4 py-2 text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
-                            (click)="openMobileGalleryDetail(gallery.id)">
-                            Ver galeria
-                          </button>
-                          @if (pendingCaptures().length > 0) {
-                            <button
-                              type="button"
-                              class="rounded-full border border-emerald-400/40 px-4 py-2 text-emerald-200 transition hover:bg-emerald-500/20 focus:outline-none focus:ring-2 focus:ring-emerald-400/40"
-                              (click)="assignPendingToGallery(gallery.id)">
-                              Enviar capturas
-                            </button>
-                          }
-                        </div>
+            @if (galleries().length === 0) {
+              <div class="mt-24 flex flex-col items-center justify-center gap-3 text-center text-gray-300">
+                <svg class="h-12 w-12 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="0.5" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
+                </svg>
+                <h3 class="text-lg font-medium">Nenhuma galeria ainda</h3>
+                <p class="text-sm text-gray-400">Crie uma galeria para começar a capturar suas memórias.</p>
+              </div>
+            } @else {
+              <div class="space-y-4">
+                @for (gallery of galleries(); track gallery.id) {
+                  <div
+                    class="flex items-center gap-4 rounded-3xl border border-white/10 bg-white/5 p-4 transition hover:bg-white/10 focus-within:ring-2 focus-within:ring-white/30"
+                    (click)="selectMobileCaptureGallery(gallery.id)"
+                    data-cursor-pointer>
+                    <div class="h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl border border-white/10 bg-black/40">
+                      <img
+                        [src]="getGalleryCover(gallery)"
+                        class="h-full w-full object-cover"
+                        loading="lazy"
+                        alt="Prévia da galeria {{ gallery.name }}">
+                    </div>
+                    <div class="min-w-0 flex-1">
+                      <div class="flex items-center gap-2">
+                        <h3 class="truncate text-base font-semibold text-white">{{ gallery.name }}</h3>
+                        @if (mobileCaptureGalleryId() === gallery.id) {
+                          <span class="rounded-full border border-emerald-400/40 px-2 py-0.5 text-[10px] uppercase tracking-[0.3em] text-emerald-200">ativo</span>
+                        }
                       </div>
-                      <div class="mt-4 flex flex-wrap items-center gap-3 text-xs text-gray-400">
-                        <button
-                          type="button"
-                          class="rounded-full border border-white/20 px-3 py-1 text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
-                          (click)="useGalleryForCapture(gallery.id)">
-                          Usar como destino
-                        </button>
-                        <button
-                          type="button"
-                          class="rounded-full border border-red-500/40 px-3 py-1 text-red-200 transition hover:bg-red-500/20 focus:outline-none focus:ring-2 focus:ring-red-400/40"
-                          (click)="deleteGallery(gallery.id)">
-                          Excluir
-                        </button>
+                      <p class="mt-1 truncate text-xs text-gray-400">
+                        {{ gallery.description || 'Sem descrição' }}
+                      </p>
+                      <div class="mt-2 flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.24em] text-gray-500">
+                        @if (gallery.createdAt) {
+                          <span>{{ gallery.createdAt }}</span>
+                        }
+                        <span>{{ gallery.imageUrls.length }} fotos</span>
                       </div>
                     </div>
-                  }
-                </div>
-              }
-            </div>
+                    <button
+                      type="button"
+                      class="rounded-full border border-white/20 px-4 py-2 text-xs font-semibold text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
+                      (click)="$event.stopPropagation(); openMobileGalleryDetail(gallery.id)">
+                      Entrar
+                    </button>
+                  </div>
+                }
+              </div>
+            }
           </div>
         </div>
       }
@@ -178,43 +163,6 @@
           </div>
         </div>
       }
-    }
-    @if (mobileGalleryPickerOpen()) {
-      <div class="fixed inset-0 z-40 flex items-end justify-center bg-black/75 px-4 pb-6">
-        <div class="w-full max-w-md rounded-3xl bg-zinc-950 p-6">
-          <div class="mb-4 flex items-center justify-between">
-            <h2 class="text-base font-semibold text-white">Selecionar galeria</h2>
-            <button
-              type="button"
-              class="text-sm text-gray-400 transition hover:text-gray-200 focus:outline-none"
-              (click)="closeMobileGalleryPicker()">
-              Fechar
-            </button>
-          </div>
-          <div class="flex flex-col gap-3">
-            @for (gallery of galleries(); track gallery.id) {
-              <button
-                type="button"
-                class="flex items-center justify-between rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-left transition hover:bg-black/30 focus:outline-none focus:ring-2 focus:ring-white/30"
-                (click)="selectMobileCaptureGallery(gallery.id)">
-                <div class="flex flex-col">
-                  <span class="text-sm font-semibold text-white">{{ gallery.name }}</span>
-                  <span class="text-xs text-gray-400">{{ gallery.imageUrls.length }} fotos</span>
-                </div>
-                @if (mobileCaptureGalleryId() === gallery.id) {
-                  <span class="text-[10px] uppercase tracking-[0.3em] text-emerald-300">ativo</span>
-                }
-              </button>
-            }
-            <button
-              type="button"
-              class="rounded-2xl border border-white/15 bg-white/5 px-4 py-3 text-sm font-semibold text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30"
-              (click)="openGalleryCreationDialogForMobileCapture()">
-              Criar nova galeria
-            </button>
-          </div>
-        </div>
-      </div>
     }
   } @else {
     @if (currentView() === 'galleries') {

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -514,7 +514,6 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     return this.pendingCaptures().includes(last);
   });
   mobileView = signal<'capture' | 'galleries' | 'galleryDetail'>('capture');
-  mobileGalleryPickerOpen = signal(false);
   mobileCaptureGalleryId = signal<string | null>(null);
   mobileCaptureGallery = computed(() => {
     const captureId = this.mobileCaptureGalleryId();
@@ -949,7 +948,6 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     if (isMobile) {
       if (!previousState) {
         this.mobileView.set('capture');
-        this.mobileGalleryPickerOpen.set(false);
         this.mobileCommandPanelVisible.set(false);
       }
       this.scheduleMobilePanelReveal(previousState ? 600 : 400);
@@ -957,7 +955,6 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
       this.mobileCommandPanelVisible.set(false);
       this.clearMobileScrollTimeout();
       this.lastMobileScrollTop = 0;
-      this.mobileGalleryPickerOpen.set(false);
     }
   }
 
@@ -1092,16 +1089,14 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   openMobileGalleryPicker(): void {
-    this.mobileGalleryPickerOpen.set(true);
-  }
-
-  closeMobileGalleryPicker(): void {
-    this.mobileGalleryPickerOpen.set(false);
+    this.currentView.set('galleries');
+    this.mobileView.set('galleries');
+    this.handleMobileNavigationTransition();
   }
 
   selectMobileCaptureGallery(galleryId: string): void {
     this.mobileCaptureGalleryId.set(galleryId);
-    this.closeMobileGalleryPicker();
+    this.showMobileCapture();
   }
 
   prepareMobileCapture(): void {
@@ -1116,7 +1111,6 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
 
   openGalleryCreationDialogForMobileCapture(): void {
     this.assignNextGalleryToMobileCapture = true;
-    this.closeMobileGalleryPicker();
     this.openGalleryCreationDialog();
   }
 


### PR DESCRIPTION
## Summary
- substitui o antigo modal de seleção por uma página dedicada de galerias no fluxo mobile, exibindo miniatura, descrição truncada, data e contagem de fotos com botão para entrar na galeria
- ajusta os handlers de navegação mobile para abrir a listagem como nova tela e retornar para a captura ao selecionar uma galeria de destino

## Testing
- npm run lint *(script ausente)*
- npm run typecheck *(script ausente)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69162df6c480832183726ed1d6784119)