### PR TITLE
Ajusta layout do seletor de galeria na captura mobile

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -12,26 +12,100 @@
       @case ('capture') {
         <div class="flex min-h-screen flex-col bg-black text-white">
           <div class="flex-1 px-6 pt-8 pb-10">
-            <app-webcam-capture
-              [variant]="'mobile'"
-              [captureAllowed]="!!mobileCaptureGallery()"
-              (prepareCapture)="prepareMobileCapture()"
-              (capture)="onCaptureComplete($event)">
-            </app-webcam-capture>
-            <div class="mt-6">
-              <button
-                type="button"
-                class="w-full rounded-full border border-white/15 bg-white/5 px-5 py-3 text-left transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30"
-                (click)="openMobileGalleryPicker()">
-                <span class="block text-[11px] uppercase tracking-[0.32em] text-gray-500">Galeria alvo</span>
-                <span class="mt-1 block truncate text-sm font-semibold text-white">
-                  @if (mobileCaptureGallery()) {
-                    {{ mobileCaptureGallery()!.name }}
-                  } @else {
-                    Selecionar galeria
-                  }
-                </span>
-              </button>
+            <div class="flex h-full flex-col gap-6">
+              <app-webcam-capture
+                [variant]="'mobile'"
+                [captureAllowed]="!!mobileCaptureGallery()"
+                (prepareCapture)="prepareMobileCapture()"
+                (capture)="onCaptureComplete($event)">
+              </app-webcam-capture>
+
+              @if (mobileCaptureGallery()) {
+                <button
+                  type="button"
+                  class="group flex w-full items-center gap-4 rounded-3xl border border-white/10 bg-white/5 p-4 text-left transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30"
+                  (click)="openMobileGalleryPicker()"
+                  data-cursor-pointer>
+                  <div class="h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl border border-white/10 bg-black/40">
+                    <img
+                      [src]="getGalleryCover(mobileCaptureGallery()!)"
+                      class="h-full w-full object-cover"
+                      loading="lazy"
+                      alt="Prévia da galeria {{ mobileCaptureGallery()!.name }}">
+                  </div>
+                  <div class="min-w-0 flex-1">
+                    <div class="flex items-center gap-2">
+                      <h3 class="truncate text-base font-semibold text-white">{{ mobileCaptureGallery()!.name }}</h3>
+                      <span class="rounded-full border border-emerald-400/40 px-2 py-0.5 text-[10px] uppercase tracking-[0.3em] text-emerald-200">ativo</span>
+                    </div>
+                    <p class="mt-1 truncate text-xs text-gray-400">
+                      {{ mobileCaptureGallery()!.description || 'Sem descrição' }}
+                    </p>
+                    <div class="mt-2 flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.24em] text-gray-500">
+                      @if (mobileCaptureGallery()!.createdAt) {
+                        <span>{{ mobileCaptureGallery()!.createdAt }}</span>
+                      }
+                      <span>{{ mobileCaptureGallery()!.imageUrls.length }} fotos</span>
+                    </div>
+                  </div>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    class="h-5 w-5 text-gray-400 transition group-hover:text-white">
+                    <path
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="1.5"
+                      d="M9 5l7 7-7 7" />
+                  </svg>
+                </button>
+              } @else {
+                <button
+                  type="button"
+                  class="flex w-full items-center gap-4 rounded-3xl border border-dashed border-white/20 bg-white/5 p-4 text-left transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30"
+                  (click)="openMobileGalleryPicker()"
+                  data-cursor-pointer>
+                  <div class="h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl border border-white/10 bg-black/40">
+                    <div class="flex h-full w-full items-center justify-center text-gray-500">
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke-width="1.5"
+                        stroke="currentColor"
+                        class="h-6 w-6">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                      </svg>
+                    </div>
+                  </div>
+                  <div class="min-w-0 flex-1">
+                    <div class="flex items-center gap-2">
+                      <h3 class="truncate text-base font-semibold text-white">Selecionar galeria</h3>
+                    </div>
+                    <p class="mt-1 truncate text-xs text-gray-400">
+                      Escolha uma galeria para salvar suas capturas.
+                    </p>
+                    <div class="mt-2 flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.24em] text-gray-500">
+                      <span>Sem data</span>
+                      <span>0 fotos</span>
+                    </div>
+                  </div>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    class="h-5 w-5 text-gray-400">
+                    <path
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="1.5"
+                      d="M9 5l7 7-7 7" />
+                  </svg>
+                </button>
+              }
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- posiciona o seletor de galeria mobile imediatamente abaixo da visualização da câmera
- replica o cartão de galeria existente para exibir imagem, descrição, data e quantidade de fotos da galeria ativa
- adiciona estado vazio coerente quando nenhuma galeria está selecionada

## Testing
- not run (npm run lint indisponível)
- not run (npm run typecheck indisponível)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691635b8c9f08321bd7c0204d0070991)