### PR TITLE
Handle missing import.meta.env in environment helper

### DIFF
--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,8 @@ const DEFAULT_SUPABASE_ANON_KEY =
 const DEFAULT_SUPABASE_BUCKET = 'gallery-images';
 
 function readEnv(key: keyof ImportMetaEnv, fallback: string): string {
-  const rawValue = import.meta.env[key];
+  const env = typeof import.meta !== 'undefined' ? import.meta.env : undefined;
+  const rawValue = env?.[key];
   const trimmed = (rawValue ?? '').trim();
   return trimmed || fallback;
 }


### PR DESCRIPTION
## Summary
- avoid runtime crashes when `import.meta.env` is undefined by guarding access in the Supabase environment helper

## Testing
- npm run lint *(fails: script not found)*
- npm run typecheck *(fails: script not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691642817c9c83218a9c131e898b3626)