### PR TITLE
Add mobile gallery deletion controls

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -206,16 +206,34 @@
           <header class="flex items-center justify-between px-6 pt-8 pb-4 text-xs uppercase tracking-[0.3em] text-gray-500">
             <button
               type="button"
-              class="rounded-full border border-white/20 px-4 py-2 text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
+              class="rounded-full border border-white/20 p-2 text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
+              aria-label="Voltar para galerias"
               (click)="returnToMobileGalleries()">
-              ← Galerias
+              <span class="sr-only">Voltar para galerias</span>
+              <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12l7.5-7.5M3 12h18" />
+              </svg>
             </button>
-            <button
-              type="button"
-              class="rounded-full border border-white/20 px-4 py-2 text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
-              (click)="activeGallery() && useGalleryForCapture(activeGallery()!.id)">
-              Usar esta galeria
-            </button>
+            <div class="flex items-center gap-3">
+              <button
+                type="button"
+                class="rounded-full border border-white/20 px-4 py-2 text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40 disabled:cursor-not-allowed disabled:opacity-50"
+                [disabled]="!activeGallery()"
+                (click)="activeGallery() && useGalleryForCapture(activeGallery()!.id)">
+                Usar esta galeria
+              </button>
+              <button
+                type="button"
+                class="rounded-full border border-white/20 p-2 text-white transition hover:bg-red-500/20 focus:outline-none focus:ring-2 focus:ring-red-300 disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label="Excluir galeria"
+                [disabled]="!activeGallery()"
+                (click)="deleteActiveGalleryFromMobile()">
+                <span class="sr-only">Excluir galeria</span>
+                <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673A2.25 2.25 0 0 1 15.916 21.75H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                </svg>
+              </button>
+            </div>
           </header>
           <div class="px-6 pb-16">
             <div class="space-y-2">

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -1071,6 +1071,22 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     this.mobileView.set('galleryDetail');
   }
 
+  deleteActiveGalleryFromMobile(): void {
+    const activeGallery = this.activeGallery();
+    if (!activeGallery) {
+      return;
+    }
+
+    const shouldDelete = window.confirm('Tem certeza que deseja excluir esta galeria? Esta ação não pode ser desfeita.');
+    if (!shouldDelete) {
+      return;
+    }
+
+    this.galleryService.deleteGallery(activeGallery.id);
+    this.updateVisibleItems(true);
+    this.returnToMobileGalleries();
+  }
+
   returnToMobileGalleries(): void {
     this.currentView.set('galleries');
     this.mobileView.set('galleries');

--- a/src/services/gallery.service.ts
+++ b/src/services/gallery.service.ts
@@ -228,7 +228,13 @@ export class GalleryService {
 
   private async loadRemoteGalleries(): Promise<void> {
     const remoteGalleries = await this.supabaseService.fetchGalleries();
+    if (remoteGalleries === null) {
+      return;
+    }
+
     if (remoteGalleries.length === 0) {
+      this.galleries.set([]);
+      this.selectedGalleryId.set(null);
       return;
     }
 

--- a/src/services/supabase.service.ts
+++ b/src/services/supabase.service.ts
@@ -49,9 +49,9 @@ export class SupabaseService {
     console.error(`${context}:`, error);
   }
 
-  async fetchGalleries(): Promise<Gallery[]> {
+  async fetchGalleries(): Promise<Gallery[] | null> {
     if (!this.isEnabled()) {
-      return [];
+      return null;
     }
 
     try {
@@ -61,7 +61,7 @@ export class SupabaseService {
 
       if (!response.ok) {
         this.logFailure('Falha ao buscar galerias no Supabase', await response.text());
-        return [];
+        return null;
       }
 
       const data = (await response.json()) as SupabaseGalleryRecord[];
@@ -75,7 +75,7 @@ export class SupabaseService {
       }));
     } catch (error) {
       this.logUnexpected('Erro inesperado ao carregar galerias do Supabase', error);
-      return [];
+      return null;
     }
   }
 


### PR DESCRIPTION
## Summary
- add icon buttons for navigating back and deleting a gallery in the mobile gallery detail header
- implement a mobile gallery deletion flow that confirms the action, syncs with Supabase, and returns to the gallery list

## Testing
- npm run lint *(fails: missing script)*
- npm run typecheck *(fails: missing script)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69164c4324fc8321a57c3c69c2363648)