### PR TITLE
Ajusta layout mobile da captura

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -12,101 +12,145 @@
       @case ('capture') {
         <div class="flex min-h-screen flex-col bg-black text-white">
           <div class="flex-1 px-6 pt-8 pb-10">
-            <div class="flex h-full flex-col gap-6">
-              <app-webcam-capture
-                [variant]="'mobile'"
-                [captureAllowed]="!!mobileCaptureGallery()"
-                (prepareCapture)="prepareMobileCapture()"
-                (capture)="onCaptureComplete($event)">
-              </app-webcam-capture>
-
-              @if (mobileCaptureGallery()) {
-                <button
-                  type="button"
-                  class="group flex w-full items-center gap-4 rounded-3xl border border-white/10 bg-white/5 p-4 text-left transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30"
-                  (click)="openMobileGalleryPicker()"
-                  data-cursor-pointer>
-                  <div class="h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl border border-white/10 bg-black/40">
-                    <img
-                      [src]="getGalleryCover(mobileCaptureGallery()!)"
-                      class="h-full w-full object-cover"
-                      loading="lazy"
-                      alt="Prévia da galeria {{ mobileCaptureGallery()!.name }}">
-                  </div>
-                  <div class="min-w-0 flex-1">
-                    <div class="flex items-center gap-2">
-                      <h3 class="truncate text-base font-semibold text-white">{{ mobileCaptureGallery()!.name }}</h3>
-                      <span class="rounded-full border border-emerald-400/40 px-2 py-0.5 text-[10px] uppercase tracking-[0.3em] text-emerald-200">ativo</span>
+            <app-webcam-capture
+              class="h-full"
+              [variant]="'mobile'"
+              [captureAllowed]="!!mobileCaptureGallery()"
+              (prepareCapture)="prepareMobileCapture()"
+              (capture)="onCaptureComplete($event)">
+              <ng-container ngProjectAs="[mobileGallerySelection]">
+                @if (galleries().length === 0) {
+                  <button
+                    type="button"
+                    class="flex w-full items-center gap-4 rounded-3xl border border-dashed border-white/20 bg-white/5 p-4 text-left transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30"
+                    (click)="openGalleryCreationDialogForMobileCapture()"
+                    data-cursor-pointer>
+                    <div class="h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl border border-white/10 bg-black/40">
+                      <div class="flex h-full w-full items-center justify-center text-gray-500">
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke-width="1.5"
+                          stroke="currentColor"
+                          class="h-6 w-6">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                        </svg>
+                      </div>
                     </div>
-                    <p class="mt-1 truncate text-xs text-gray-400">
-                      {{ mobileCaptureGallery()!.description || 'Sem descrição' }}
-                    </p>
-                    <div class="mt-2 flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.24em] text-gray-500">
-                      @if (mobileCaptureGallery()!.createdAt) {
-                        <span>{{ mobileCaptureGallery()!.createdAt }}</span>
-                      }
-                      <span>{{ mobileCaptureGallery()!.imageUrls.length }} fotos</span>
+                    <div class="min-w-0 flex-1">
+                      <div class="flex items-center gap-2">
+                        <h3 class="truncate text-base font-semibold text-white">Crie sua primeira galeria</h3>
+                      </div>
+                      <p class="mt-1 truncate text-xs text-gray-400">
+                        Você ainda não tem galerias. Toque para começar.
+                      </p>
+                      <div class="mt-2 flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.24em] text-gray-500">
+                        <span>Sem data</span>
+                        <span>0 fotos</span>
+                      </div>
                     </div>
-                  </div>
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    class="h-5 w-5 text-gray-400 transition group-hover:text-white">
-                    <path
-                      stroke="currentColor"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="1.5"
-                      d="M9 5l7 7-7 7" />
-                  </svg>
-                </button>
-              } @else {
-                <button
-                  type="button"
-                  class="flex w-full items-center gap-4 rounded-3xl border border-dashed border-white/20 bg-white/5 p-4 text-left transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30"
-                  (click)="openMobileGalleryPicker()"
-                  data-cursor-pointer>
-                  <div class="h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl border border-white/10 bg-black/40">
-                    <div class="flex h-full w-full items-center justify-center text-gray-500">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke-width="1.5"
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      class="h-5 w-5 text-gray-400">
+                      <path
                         stroke="currentColor"
-                        class="h-6 w-6">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-                      </svg>
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                        d="M9 5l7 7-7 7" />
+                    </svg>
+                  </button>
+                } @else if (mobileCaptureGallery()) {
+                  <button
+                    type="button"
+                    class="group flex w-full items-center gap-4 rounded-3xl border border-white/10 bg-white/5 p-4 text-left transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30"
+                    (click)="openMobileGalleryPicker()"
+                    data-cursor-pointer>
+                    <div class="h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl border border-white/10 bg-black/40">
+                      <img
+                        [src]="getGalleryCover(mobileCaptureGallery()!)"
+                        class="h-full w-full object-cover"
+                        loading="lazy"
+                        alt="Prévia da galeria {{ mobileCaptureGallery()!.name }}">
                     </div>
-                  </div>
-                  <div class="min-w-0 flex-1">
-                    <div class="flex items-center gap-2">
-                      <h3 class="truncate text-base font-semibold text-white">Selecionar galeria</h3>
+                    <div class="min-w-0 flex-1">
+                      <div class="flex items-center gap-2">
+                        <h3 class="truncate text-base font-semibold text-white">{{ mobileCaptureGallery()!.name }}</h3>
+                        <span class="rounded-full border border-emerald-400/40 px-2 py-0.5 text-[10px] uppercase tracking-[0.3em] text-emerald-200">ativo</span>
+                      </div>
+                      <p class="mt-1 truncate text-xs text-gray-400">
+                        {{ mobileCaptureGallery()!.description || 'Sem descrição' }}
+                      </p>
+                      <div class="mt-2 flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.24em] text-gray-500">
+                        @if (mobileCaptureGallery()!.createdAt) {
+                          <span>{{ mobileCaptureGallery()!.createdAt }}</span>
+                        }
+                        <span>{{ mobileCaptureGallery()!.imageUrls.length }} fotos</span>
+                      </div>
                     </div>
-                    <p class="mt-1 truncate text-xs text-gray-400">
-                      Escolha uma galeria para salvar suas capturas.
-                    </p>
-                    <div class="mt-2 flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.24em] text-gray-500">
-                      <span>Sem data</span>
-                      <span>0 fotos</span>
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      class="h-5 w-5 text-gray-400 transition group-hover:text-white">
+                      <path
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                        d="M9 5l7 7-7 7" />
+                    </svg>
+                  </button>
+                } @else {
+                  <button
+                    type="button"
+                    class="flex w-full items-center gap-4 rounded-3xl border border-dashed border-white/20 bg-white/5 p-4 text-left transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30"
+                    (click)="openMobileGalleryPicker()"
+                    data-cursor-pointer>
+                    <div class="h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl border border-white/10 bg-black/40">
+                      <div class="flex h-full w-full items-center justify-center text-gray-500">
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke-width="1.5"
+                          stroke="currentColor"
+                          class="h-6 w-6">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                        </svg>
+                      </div>
                     </div>
-                  </div>
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    class="h-5 w-5 text-gray-400">
-                    <path
-                      stroke="currentColor"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="1.5"
-                      d="M9 5l7 7-7 7" />
-                  </svg>
-                </button>
-              }
-            </div>
+                    <div class="min-w-0 flex-1">
+                      <div class="flex items-center gap-2">
+                        <h3 class="truncate text-base font-semibold text-white">Selecionar galeria</h3>
+                      </div>
+                      <p class="mt-1 truncate text-xs text-gray-400">
+                        Escolha uma galeria para salvar suas capturas.
+                      </p>
+                      <div class="mt-2 flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.24em] text-gray-500">
+                        <span>Sem data</span>
+                        <span>0 fotos</span>
+                      </div>
+                    </div>
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      class="h-5 w-5 text-gray-400">
+                      <path
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                        d="M9 5l7 7-7 7" />
+                    </svg>
+                  </button>
+                }
+              </ng-container>
+            </app-webcam-capture>
           </div>
         </div>
       }

--- a/src/components/webcam-capture/webcam-capture.component.ts
+++ b/src/components/webcam-capture/webcam-capture.component.ts
@@ -8,9 +8,9 @@ import { ThemeService } from '../../services/theme.service';
   template: `
     @if (isMobileVariant()) {
       <div class="flex h-full flex-col">
-        <div class="flex-1 px-2 pb-6">
-          <div class="flex h-full flex-col items-center justify-between gap-8">
-            <div class="flex-1 w-full max-w-[26rem] select-none" data-cursor-pointer (click)="toggleGridOverlay()">
+        <div class="flex-1 px-4 pt-8">
+          <div class="mx-auto flex h-full w-full max-w-[26rem] flex-col items-center">
+            <div class="w-full select-none" data-cursor-pointer (click)="toggleGridOverlay()">
               <div
                 class="relative aspect-square w-full overflow-hidden rounded-3xl border border-white/10 bg-black shadow-[0_10px_40px_rgba(0,0,0,0.6)]">
                 <video
@@ -48,54 +48,54 @@ import { ThemeService } from '../../services/theme.service';
                     {{ countdown() }}
                   </div>
                 }
-
-                <div class="pointer-events-none absolute bottom-3 left-1/2 -translate-x-1/2 text-xs font-medium text-gray-400">
-                  Toque para exibir a grade
-                </div>
               </div>
             </div>
 
-            <div class="flex w-full flex-col items-center gap-6">
-              <div class="flex w-full items-center justify-center gap-16">
-                <button
-                  type="button"
-                  (click)="cycleTimerSetting()"
-                  class="relative flex h-14 w-14 items-center justify-center rounded-full bg-white/10 text-white transition hover:bg-white/20 focus:outline-none"
-                  [disabled]="!isStreaming()"
-                  [class.opacity-50]="!isStreaming()">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="h-6 w-6">
-                    <circle cx="12" cy="12" r="10"></circle>
-                    <polyline points="12 6 12 12 16 14"></polyline>
-                  </svg>
-                  <span class="absolute -bottom-5 text-[11px] font-medium uppercase tracking-[0.24em] text-gray-300">{{ timerLabel() }}</span>
-                </button>
-
-                <button
-                  type="button"
-                  (click)="captureImage()"
-                  class="flex h-24 w-24 items-center justify-center rounded-full border-[6px] border-white bg-black/60 shadow-[0_0_0_10px_rgba(0,0,0,0.45)] transition active:scale-95"
-                  [disabled]="!isStreaming() || (countdown() !== null) || !captureAllowed()"
-                  [class.opacity-50]="!isStreaming() || (countdown() !== null) || !captureAllowed()">
-                  <span class="sr-only">Capturar foto</span>
-                </button>
-
-                @if (availableCameras().length > 1) {
-                  <button
-                    type="button"
-                    (click)="cycleCamera()"
-                    class="flex h-14 w-14 items-center justify-center rounded-full bg-white/10 text-white transition hover:bg-white/20 focus:outline-none"
-                    [disabled]="!isStreaming()"
-                    [class.opacity-50]="!isStreaming()">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="h-6 w-6">
-                      <path d="M23 4v6h-6"></path>
-                      <path d="M1 20v-6h6"></path>
-                      <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10"></path>
-                      <path d="M20.49 15a9 9 0 0 1-14.85 3.36L1 14"></path>
-                    </svg>
-                  </button>
-                }
-              </div>
+            <div class="mt-3 w-full">
+              <ng-content select="[mobileGallerySelection]"></ng-content>
             </div>
+          </div>
+        </div>
+
+        <div class="px-8 pb-10 pt-6">
+          <div class="flex items-center justify-center gap-16">
+            <button
+              type="button"
+              (click)="cycleTimerSetting()"
+              class="relative flex h-14 w-14 items-center justify-center rounded-full bg-white/10 text-white transition hover:bg-white/20 focus:outline-none"
+              [disabled]="!isStreaming()"
+              [class.opacity-50]="!isStreaming()">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="h-6 w-6">
+                <circle cx="12" cy="12" r="10"></circle>
+                <polyline points="12 6 12 12 16 14"></polyline>
+              </svg>
+              <span class="absolute -bottom-5 text-[11px] font-medium uppercase tracking-[0.24em] text-gray-300">{{ timerLabel() }}</span>
+            </button>
+
+            <button
+              type="button"
+              (click)="captureImage()"
+              class="flex h-24 w-24 items-center justify-center rounded-full border-[6px] border-white bg-black/60 shadow-[0_0_0_10px_rgba(0,0,0,0.45)] transition active:scale-95"
+              [disabled]="!isStreaming() || (countdown() !== null) || !captureAllowed()"
+              [class.opacity-50]="!isStreaming() || (countdown() !== null) || !captureAllowed()">
+              <span class="sr-only">Capturar foto</span>
+            </button>
+
+            @if (availableCameras().length > 1) {
+              <button
+                type="button"
+                (click)="cycleCamera()"
+                class="flex h-14 w-14 items-center justify-center rounded-full bg-white/10 text-white transition hover:bg-white/20 focus:outline-none"
+                [disabled]="!isStreaming()"
+                [class.opacity-50]="!isStreaming()">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="h-6 w-6">
+                  <path d="M23 4v6h-6"></path>
+                  <path d="M1 20v-6h6"></path>
+                  <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10"></path>
+                  <path d="M20.49 15a9 9 0 0 1-14.85 3.36L1 14"></path>
+                </svg>
+              </button>
+            }
           </div>
         </div>
 


### PR DESCRIPTION
## Resumo
- reorganiza o layout mobile do componente de captura para fixar os botões na base e remover o texto da área de pré-visualização
- adiciona slot para projetar o cartão de seleção de galeria logo abaixo da pré-visualização 1:1
- cria empty state dedicado quando não há galerias disponíveis no fluxo mobile

## Testes
- `npm run lint` *(falhou: script ausente)*
- `npm run typecheck` *(falhou: script ausente)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916502997d08321bf028d9c10539839)