### PR TITLE
Fix gallery deletion via context menu

### DIFF
--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -1670,7 +1670,14 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   deleteGallery(id: string): void {
+    const activeGallery = this.galleryService.selectedGalleryId();
     this.galleryService.deleteGallery(id);
+
+    if (activeGallery === id) {
+      this.backToGalleries();
+    }
+
+    this.updateVisibleItems(true);
   }
 
   editGalleryContextMenu(): void {


### PR DESCRIPTION
## Summary
- ensure deleting a gallery refreshes the grid after removal
- return to the galleries view when the active gallery is deleted from the context menu

## Testing
- npm run lint *(fails: Missing script "lint")*
- npm run typecheck *(fails: Missing script "typecheck")*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916555f3a248321bf8ec1b7f7f78649)