### PR TITLE
Ajusta interação do card mobile e destaque de seleção

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -64,46 +64,24 @@
                     </svg>
                   </button>
                 } @else if (mobileCaptureGallery()) {
-                  <button
-                    type="button"
-                    class="group flex w-full items-center gap-4 rounded-3xl border border-white/10 bg-white/5 p-4 text-left transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30"
-                    (click)="openMobileGalleryPicker()"
-                    data-cursor-pointer>
-                    <div class="h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl border border-white/10 bg-black/40">
-                      <img
-                        [src]="getGalleryCover(mobileCaptureGallery()!)"
-                        class="h-full w-full object-cover"
-                        loading="lazy"
-                        alt="Prévia da galeria {{ mobileCaptureGallery()!.name }}">
+                  <div class="space-y-3">
+                    <app-mobile-gallery-card
+                      [gallery]="mobileCaptureGallery()!"
+                      [coverUrl]="getGalleryCover(mobileCaptureGallery()!)"
+                      [active]="true"
+                      (select)="openMobileGalleryPicker()"
+                      (open)="openMobileGalleryDetail(mobileCaptureGallery()!.id)"
+                    />
+                    <div class="flex justify-end">
+                      <button
+                        type="button"
+                        class="rounded-full border border-white/20 px-4 py-2 text-[11px] uppercase tracking-[0.24em] text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
+                        (click)="openMobileGalleryPicker()"
+                        data-cursor-pointer>
+                        Trocar galeria
+                      </button>
                     </div>
-                    <div class="min-w-0 flex-1">
-                      <div class="flex items-center gap-2">
-                        <h3 class="truncate text-base font-semibold text-white">{{ mobileCaptureGallery()!.name }}</h3>
-                        <span class="rounded-full border border-emerald-400/40 px-2 py-0.5 text-[10px] uppercase tracking-[0.3em] text-emerald-200">ativo</span>
-                      </div>
-                      <p class="mt-1 truncate text-xs text-gray-400">
-                        {{ mobileCaptureGallery()!.description || 'Sem descrição' }}
-                      </p>
-                      <div class="mt-2 flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.24em] text-gray-500">
-                        @if (mobileCaptureGallery()!.createdAt) {
-                          <span>{{ mobileCaptureGallery()!.createdAt }}</span>
-                        }
-                        <span>{{ mobileCaptureGallery()!.imageUrls.length }} fotos</span>
-                      </div>
-                    </div>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      class="h-5 w-5 text-gray-400 transition group-hover:text-white">
-                      <path
-                        stroke="currentColor"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="1.5"
-                        d="M9 5l7 7-7 7" />
-                    </svg>
-                  </button>
+                  </div>
                 } @else {
                   <button
                     type="button"
@@ -182,63 +160,13 @@
             } @else {
               <div class="space-y-4">
                 @for (gallery of galleries(); track gallery.id) {
-                  <div
-                    class="flex items-center gap-4 rounded-3xl border border-white/10 bg-white/5 p-4 transition hover:bg-white/10 focus-within:ring-2 focus-within:ring-white/30"
-                    (click)="selectMobileCaptureGallery(gallery.id)"
-                    data-cursor-pointer>
-                    <div class="h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl border border-white/10 bg-black/40">
-                      <img
-                        [src]="getGalleryCover(gallery)"
-                        class="h-full w-full object-cover"
-                        loading="lazy"
-                        alt="Prévia da galeria {{ gallery.name }}">
-                    </div>
-                    <div class="min-w-0 flex-1">
-                      <div class="flex items-center gap-2">
-                        <h3 class="truncate text-base font-semibold text-white">{{ gallery.name }}</h3>
-                        @if (mobileCaptureGalleryId() === gallery.id) {
-                          <span class="rounded-full border border-emerald-400/40 px-2 py-0.5 text-[10px] uppercase tracking-[0.3em] text-emerald-200">ativo</span>
-                        }
-                      </div>
-                      <p class="mt-1 truncate text-xs text-gray-400">
-                        {{ gallery.description || 'Sem descrição' }}
-                      </p>
-                      <div class="mt-2 flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.24em] text-gray-500">
-                        @if (gallery.createdAt) {
-                          <span>{{ gallery.createdAt }}</span>
-                        }
-                        <span>{{ gallery.imageUrls.length }} fotos</span>
-                      </div>
-                    </div>
-                    <button
-                      type="button"
-                      class="rounded-full border border-white/20 p-3 text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
-                      aria-label="Abrir galeria"
-                      (click)="$event.stopPropagation(); openMobileGalleryDetail(gallery.id)">
-                      <svg
-                        aria-hidden="true"
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        class="h-5 w-5"
-                      >
-                        <path
-                          stroke="currentColor"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="1.5"
-                          d="M2.25 12s2.608-6.75 9.75-6.75 9.75 6.75 9.75 6.75-2.608 6.75-9.75 6.75S2.25 12 2.25 12Z"
-                        />
-                        <path
-                          stroke="currentColor"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="1.5"
-                          d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
+                  <app-mobile-gallery-card
+                    [gallery]="gallery"
+                    [coverUrl]="getGalleryCover(gallery)"
+                    [active]="mobileCaptureGalleryId() === gallery.id"
+                    (select)="selectMobileCaptureGallery(gallery.id)"
+                    (open)="openMobileGalleryDetail(gallery.id)"
+                  />
                 }
               </div>
             }

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -6,6 +6,7 @@ import { WebcamCaptureComponent } from './components/webcam-capture/webcam-captu
 import { GalleryEditorComponent } from './components/gallery-editor/gallery-editor.component';
 import { GalleryCreationDialogComponent } from './components/gallery-creation-dialog/gallery-creation-dialog.component';
 import { InfoDialogComponent } from './components/info-dialog/info-dialog.component';
+import { MobileGalleryCardComponent } from './components/mobile-gallery-card/mobile-gallery-card.component';
 
 import { Gallery } from './interfaces/gallery.interface';
 import { InteractiveCursor } from './services/interactive-cursor';
@@ -59,7 +60,7 @@ interface ExpandedItem {
 
 @Component({
   selector: 'app-root',
-  imports: [CommonModule, ContextMenuComponent, WebcamCaptureComponent, GalleryEditorComponent, GalleryCreationDialogComponent, InfoDialogComponent],
+  imports: [CommonModule, ContextMenuComponent, WebcamCaptureComponent, GalleryEditorComponent, GalleryCreationDialogComponent, InfoDialogComponent, MobileGalleryCardComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/components/mobile-gallery-card/mobile-gallery-card.component.ts
+++ b/src/components/mobile-gallery-card/mobile-gallery-card.component.ts
@@ -1,0 +1,90 @@
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { Gallery } from '../../interfaces/gallery.interface';
+
+@Component({
+  selector: 'app-mobile-gallery-card',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div
+      class="group relative flex w-full items-center gap-4 rounded-3xl border border-white/10 bg-white/5 p-4 transition hover:bg-white/10 focus-within:ring-2 focus-within:ring-white/30"
+      [class.cursor-default]="!selectable()"
+      [attr.data-cursor-pointer]="selectable() ? '' : null"
+      (click)="handleSelect($event)">
+      <div class="h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl border border-white/10 bg-black/40">
+        <img
+          [src]="coverUrl()"
+          class="h-full w-full object-cover"
+          loading="lazy"
+          [attr.alt]="'Prévia da galeria ' + gallery().name" />
+      </div>
+      <div class="min-w-0 flex-1">
+        <h3 class="truncate text-base font-semibold text-white">{{ gallery().name }}</h3>
+        <p class="mt-1 truncate text-xs text-gray-400">
+          {{ gallery().description || 'Sem descrição' }}
+        </p>
+        <div class="mt-2 flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.24em] text-gray-500">
+          @if (gallery().createdAt) {
+            <span>{{ gallery().createdAt }}</span>
+          }
+          <span>{{ gallery().imageUrls.length }} fotos</span>
+        </div>
+      </div>
+      <button
+        type="button"
+        class="rounded-full border border-white/20 p-3 text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
+        [attr.aria-label]="viewLabel()"
+        (click)="handleOpen($event)">
+        <svg
+          aria-hidden="true"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          class="h-5 w-5">
+          <path
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1.5"
+            d="M2.25 12s2.608-6.75 9.75-6.75 9.75 6.75 9.75 6.75-2.608 6.75-9.75 6.75S2.25 12 2.25 12Z" />
+          <path
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1.5"
+            d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+        </svg>
+      </button>
+      @if (active()) {
+        <span class="pointer-events-none absolute inset-x-0 bottom-0 h-[3px] rounded-b-3xl bg-emerald-400/80"></span>
+      }
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MobileGalleryCardComponent {
+  gallery = input.required<Gallery>();
+  coverUrl = input.required<string>();
+  active = input<boolean>(false);
+  selectable = input<boolean>(true);
+  viewLabel = input<string>('Abrir galeria');
+
+  select = output<void>();
+  open = output<void>();
+
+  handleSelect(event: MouseEvent): void {
+    if (!this.selectable()) {
+      return;
+    }
+
+    event.stopPropagation();
+    this.select.emit();
+  }
+
+  handleOpen(event: MouseEvent): void {
+    event.stopPropagation();
+    this.open.emit();
+  }
+}


### PR DESCRIPTION
## Summary
- remove a tag "ativo" do card mobile e adiciona faixa inferior de 3px para evidenciar a seleção
- faz o card exibido na captura abrir a listagem ao toque, mantendo o botão de olho para acessar os detalhes

## Testing
- npm run lint *(fails: Missing script: "lint")*
- npm run typecheck *(fails: Missing script: "typecheck")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69165f6abbcc832198d4d23d7f79b169)