### PR TITLE
Corrige casts de template e timeout em serviços

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -560,7 +560,7 @@
             class="w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2"
             [ngClass]="themeService.isDark() ? 'border-white/10 bg-black/40 focus:ring-white/30' : 'border-slate-200 bg-white focus:ring-slate-400'"
             [value]="loginEmail()"
-            (input)="loginEmail.set(($event.target as HTMLInputElement).value)"
+            (input)="loginEmail.set($any($event.target).value)"
             [disabled]="isLoginInProgress()"
             required>
         </div>
@@ -573,7 +573,7 @@
             class="w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2"
             [ngClass]="themeService.isDark() ? 'border-white/10 bg-black/40 focus:ring-white/30' : 'border-slate-200 bg-white focus:ring-slate-400'"
             [value]="loginPassword()"
-            (input)="loginPassword.set(($event.target as HTMLInputElement).value)"
+            (input)="loginPassword.set($any($event.target).value)"
             [disabled]="isLoginInProgress()"
             required>
         </div>

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -235,7 +235,7 @@ export class AuthService {
     const secondsUntilExpiry = session.expiresAt - now;
     const refreshInSeconds = Math.max(secondsUntilExpiry - 60, 5);
 
-    this.refreshTimeoutId = window.setTimeout(() => {
+    this.refreshTimeoutId = setTimeout(() => {
       void this.refreshCurrentSession();
     }, refreshInSeconds * 1000);
   }


### PR DESCRIPTION
## Summary
- ajusta os handlers de input do formulário de login para usar `$any()` nos templates
- atualiza o agendamento de renovação de sessão para usar `setTimeout` compatível com Node

## Testing
- npm run lint *(script indisponível)*
- npm run typecheck *(script indisponível)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917299c75c48321a01343af96a4847c)