### PR TITLE
Add mobile long press login trigger

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -140,7 +140,12 @@
                     </button>
                   }
                 } @else {
-                  <div class="rounded-3xl border border-dashed border-white/20 bg-white/5 p-4 text-center text-xs text-gray-300">
+                  <div
+                    class="rounded-3xl border border-dashed border-white/20 bg-white/5 p-4 text-center text-xs text-gray-300"
+                    (pointerdown)="onMobileGallerySelectorPressStart($event)"
+                    (pointerup)="onMobileGallerySelectorPressEnd()"
+                    (pointerleave)="onMobileGallerySelectorPressCancel()"
+                    (pointercancel)="onMobileGallerySelectorPressCancel()">
                     Entre com a conta administradora para escolher uma galeria e capturar fotos.
                   </div>
                 }


### PR DESCRIPTION
## Summary
- add a 10-second long-press gesture on the mobile gallery selection hint for unauthenticated users to reveal the login modal
- manage the long-press timer lifecycle within the app component to avoid leaks when navigating away

## Testing
- npm run lint *(fails: Missing script "lint")*
- npm run typecheck *(fails: Missing script "typecheck")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69172bce62b483219fcbf38522b6d2f3)