### PR TITLE
Adjust fallback gallery thumbnail background

### DIFF
--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -48,7 +48,7 @@ const ARROW_KEYS = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'] as const;
 type ArrowKey = (typeof ARROW_KEYS)[number];
 
 const FALLBACK_GALLERY_THUMBNAIL =
-  "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 200'><rect width='300' height='200' fill='%23f3f4f6'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='%236b7280' font-family='Arial, sans-serif' font-size='28'>Sem Imagem</text></svg>";
+  "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 200'><rect width='300' height='200' fill='%23111111'/></svg>";
 
 function isArrowKey(key: string): key is ArrowKey {
   return (ARROW_KEYS as readonly string[]).includes(key);


### PR DESCRIPTION
## Summary
- replace the fallback gallery thumbnail with a plain dark backdrop slightly lighter than the body background so empty galleries no longer display placeholder text

## Testing
- npm run lint *(fails: Missing script: "lint")*
- npm run typecheck *(fails: Missing script: "typecheck")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691750dd2104832195c1a4c280a5fe72)