### PR TITLE
Add desktop entry point for admin login dialog

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -32,6 +32,28 @@
           Sair
         </button>
       </div>
+    } @else {
+      <div
+        class="pointer-events-auto flex w-full flex-col gap-2 border px-4 py-3 text-[10px] font-semibold uppercase tracking-[0.3em] shadow-lg backdrop-blur sm:w-auto sm:flex-row sm:items-center"
+        [ngClass]="[
+          themeService.isDark() ? 'border-white/15 bg-black/60 text-white/80' : 'border-slate-300/70 bg-white/85 text-slate-700',
+          isMobileLayout() ? 'rounded-t-3xl rounded-b-none' : 'rounded-full'
+        ]">
+        <span class="tracking-[0.24em] text-[9px] opacity-80 sm:text-[10px]">
+          Área administrativa
+        </span>
+        <button
+          type="button"
+          data-cursor-pointer
+          class="rounded-full border border-white/20 px-3 py-1 text-[10px] tracking-[0.32em] transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40 sm:ml-auto"
+          [ngClass]="themeService.isDark() ? 'text-white/85 hover:bg-white/10 focus:ring-white/40' : 'border-slate-400/70 text-slate-800/90 hover:bg-slate-200/60 focus:ring-slate-500/60'"
+          (click)="openLoginDialog()">
+          Entrar
+        </button>
+        <span class="text-[9px] font-normal uppercase tracking-[0.24em] text-gray-400 sm:hidden">
+          Toque e segure na lista de galerias para acessar
+        </span>
+      </div>
     }
   </div>
 


### PR DESCRIPTION
## Summary
- adiciona um call-to-action visível para abrir o diálogo de login administrativo quando o usuário não está autenticado
- mantém o painel administrativo existente para usuários logados e fornece uma dica móvel sobre o acesso por long press

## Testing
- npm run lint *(falha: script "lint" ausente no package.json)*
- npm run typecheck *(falha: script "typecheck" ausente no package.json)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69175f238458832188eb37dc2d0c6bbf)