### PR TITLE
Atualiza atalho de login administrativo

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -42,14 +42,9 @@
         <span class="tracking-[0.24em] text-[9px] opacity-80 sm:text-[10px]">
           Área administrativa
         </span>
-        <button
-          type="button"
-          data-cursor-pointer
-          class="rounded-full border border-white/20 px-3 py-1 text-[10px] tracking-[0.32em] transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40 sm:ml-auto"
-          [ngClass]="themeService.isDark() ? 'text-white/85 hover:bg-white/10 focus:ring-white/40' : 'border-slate-400/70 text-slate-800/90 hover:bg-slate-200/60 focus:ring-slate-500/60'"
-          (click)="openLoginDialog()">
-          Entrar
-        </button>
+        <span class="hidden text-[9px] uppercase tracking-[0.24em] text-gray-400 sm:ml-auto sm:block">
+          Pressione a tecla <span class="font-semibold">N</span> para acessar
+        </span>
         <span class="text-[9px] font-normal uppercase tracking-[0.24em] text-gray-400 sm:hidden">
           Toque e segure na lista de galerias para acessar
         </span>

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -411,8 +411,8 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
 
     const key = event.key.toLowerCase();
 
-    // Atalho: apenas tecla "l" sem Ctrl/Alt/Shift/Meta
-    if (!event.ctrlKey && !event.altKey && !event.metaKey && !event.shiftKey && key === 'l') {
+  // Atalho: apenas tecla "n" sem Ctrl/Alt/Meta
+    if (!event.ctrlKey && !event.altKey && !event.metaKey && key === 'n') {
       event.preventDefault();
       this.openLoginDialog();
     }


### PR DESCRIPTION
## Summary
- altera o atalho de teclado do login administrativo para a tecla N, permitindo uso com ou sem Shift
- remove o botão visível de entrada e acrescenta orientação textual para acessar o login via teclado

## Testing
- npm run lint *(fails: script missing)*
- npm run typecheck *(fails: script missing)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917650118f88321bd20f977952a595c)