### PR TITLE
Allow login dialog shortcut for unauthenticated users

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -42,12 +42,6 @@
         <span class="tracking-[0.24em] text-[9px] opacity-80 sm:text-[10px]">
           Área administrativa
         </span>
-        <span class="hidden text-[9px] uppercase tracking-[0.24em] text-gray-400 sm:ml-auto sm:block">
-          Pressione a tecla <span class="font-semibold">N</span> para acessar
-        </span>
-        <span class="text-[9px] font-normal uppercase tracking-[0.24em] text-gray-400 sm:hidden">
-          Toque e segure na lista de galerias para acessar
-        </span>
       </div>
     }
   </div>

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -833,7 +833,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
     });
 
     effect(() => {
-      if (this.canManageContent()) {
+      if (this.canManageContent() || this.isLoginDialogVisible() || this.isLoginInProgress()) {
         return;
       }
 


### PR DESCRIPTION
## Summary
- avoid forcing admin modals to close while the login dialog is visible so the shortcut works when logged out
- remove the visible instructions that revealed the login shortcut

## Testing
- npm run lint *(fails: Missing script "lint")*
- npm run typecheck *(fails: Missing script "typecheck")*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691773abdfc48321bd10d2799f541ce6)