### PR TITLE
Remove admin banner for signed-out users

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -33,17 +33,6 @@
         </button>
       </div>
     </div>
-  } @else {
-    <div
-      class="pointer-events-auto flex w-full flex-col gap-2 border px-4 py-3 text-[10px] font-semibold uppercase tracking-[0.3em] shadow-lg backdrop-blur sm:w-auto sm:flex-row sm:items-center"
-      [ngClass]="[
-        themeService.isDark() ? 'border-white/15 bg-black/60 text-white/80' : 'border-slate-300/70 bg-white/85 text-slate-700',
-        isMobileLayout() ? 'rounded-t-3xl rounded-b-none' : 'rounded-full'
-      ]">
-      <span class="tracking-[0.24em] text-[9px] opacity-80 sm:text-[10px]">
-        Área administrativa
-      </span>
-    </div>
   }
 
   @if (isMobileLayout()) {


### PR DESCRIPTION
## Summary
- remove the administrative banner that was shown to unauthenticated users on the homepage

## Testing
- npm run lint *(fails: Missing script "lint")*
- npm run typecheck *(fails: Missing script "typecheck")*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69177bf097c4832197bf7e4a163985bd)