### PR TITLE
feat: converter capturas da webcam para AVIF

### DIFF
--- a/src/services/supabase.service.ts
+++ b/src/services/supabase.service.ts
@@ -330,6 +330,9 @@ export class SupabaseService {
   }
 
   private detectExtension(contentType: string): string {
+    if (contentType.includes('avif')) {
+      return 'avif';
+    }
     if (contentType.includes('jpeg')) {
       return 'jpg';
     }

--- a/src/utils/convert-to-avif.ts
+++ b/src/utils/convert-to-avif.ts
@@ -1,0 +1,76 @@
+export async function convertToAvif(blob: Blob): Promise<{ blob: Blob; extension: string; mime: string }> {
+  const fallbackMime = blob.type || 'image/png';
+  const fallback = {
+    blob,
+    extension: detectExtension(fallbackMime),
+    mime: fallbackMime,
+  } as const;
+
+  if (typeof document === 'undefined') {
+    return fallback;
+  }
+
+  try {
+    const image = await loadImage(blob);
+    const canvas = document.createElement('canvas');
+    canvas.width = image.naturalWidth || image.width;
+    canvas.height = image.naturalHeight || image.height;
+
+    const context = canvas.getContext('2d');
+    if (!context) {
+      return fallback;
+    }
+
+    context.drawImage(image, 0, 0);
+
+    const avifBlob = await new Promise<Blob | null>(resolve => {
+      canvas.toBlob(resolve, 'image/avif', 0.8);
+    });
+
+    if (avifBlob && avifBlob.size > 0) {
+      return {
+        blob: avifBlob,
+        extension: 'avif',
+        mime: 'image/avif',
+      };
+    }
+  } catch (error) {
+    console.warn('Falha ao converter imagem para AVIF', error);
+  }
+
+  return fallback;
+}
+
+async function loadImage(blob: Blob): Promise<HTMLImageElement> {
+  const objectUrl = URL.createObjectURL(blob);
+
+  try {
+    return await new Promise<HTMLImageElement>((resolve, reject) => {
+      const image = new Image();
+      image.onload = () => resolve(image);
+      image.onerror = () => reject(new Error('Não foi possível carregar a imagem para conversão.'));
+      image.src = objectUrl;
+    });
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+function detectExtension(mime: string): string {
+  if (mime.includes('avif')) {
+    return 'avif';
+  }
+  if (mime.includes('jpeg')) {
+    return 'jpg';
+  }
+  if (mime.includes('png')) {
+    return 'png';
+  }
+  if (mime.includes('webp')) {
+    return 'webp';
+  }
+  if (mime.includes('gif')) {
+    return 'gif';
+  }
+  return 'png';
+}


### PR DESCRIPTION
## Summary
- adiciona utilitário de conversão que tenta gerar blobs AVIF com fallback para o formato original
- atualiza o componente de captura para gerar o blob da webcam, converter para AVIF e emitir a imagem convertida
- ajusta a detecção de extensão no serviço do Supabase para reconhecer image/avif e usar a extensão correta

## Testing
- npm run lint *(indisponível: script ausente)*
- npm run typecheck *(indisponível: script ausente)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691795153a6083218e475b7401e6576b)