### PR TITLE
Ensure AVIF conversions only return AVIF blobs

### DIFF
--- a/src/utils/convert-to-avif.ts
+++ b/src/utils/convert-to-avif.ts
@@ -27,7 +27,8 @@ export async function convertToAvif(blob: Blob): Promise<{ blob: Blob; extension
       canvas.toBlob(resolve, 'image/avif', 0.8);
     });
 
-    if (avifBlob && avifBlob.size > 0) {
+    if (avifBlob && avifBlob.size > 0 && avifBlob.type.includes('avif')) {
+      console.info('[convertToAvif] usando AVIF, tamanho:', avifBlob.size);
       return {
         blob: avifBlob,
         extension: 'avif',
@@ -38,6 +39,7 @@ export async function convertToAvif(blob: Blob): Promise<{ blob: Blob; extension
     console.warn('Falha ao converter imagem para AVIF', error);
   }
 
+  console.warn('[convertToAvif] fallback ativado, mantendo formato original:', fallbackMime);
   return fallback;
 }
 


### PR DESCRIPTION
## Summary
- ensure `convertToAvif` only returns the converted blob when the browser actually produced an AVIF file
- add explicit logging to clarify when AVIF conversion succeeds or falls back to the original format

## Testing
- npm run lint *(fails: script "lint" is not defined)*
- npm run typecheck *(fails: script "typecheck" is not defined)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69179851771083218a21a09bc1a79bf8)