### PR TITLE
feat: convert webcam captures to webp

### DIFF
--- a/src/components/webcam-capture/webcam-capture.component.ts
+++ b/src/components/webcam-capture/webcam-capture.component.ts
@@ -1,7 +1,7 @@
 import { Component, ChangeDetectionStrategy, output, inject, signal, viewChild, ElementRef, AfterViewInit, OnDestroy, HostListener, computed, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ThemeService } from '../../services/theme.service';
-import { convertToAvif } from '../../utils/convert-to-avif';
+import { convertToWebp } from '../../utils/convert-to-webp';
 
 @Component({
   selector: 'app-webcam-capture',
@@ -513,7 +513,7 @@ export class WebcamCaptureComponent implements AfterViewInit, OnDestroy {
       return;
     }
 
-    const { blob } = await convertToAvif(originalBlob);
+    const { blob } = await convertToWebp(originalBlob);
 
     try {
       const dataUrl = await this.blobToDataUrl(blob);

--- a/src/services/supabase.service.ts
+++ b/src/services/supabase.service.ts
@@ -159,6 +159,11 @@ export class SupabaseService {
       const { blob, extension, contentType } = this.dataUrlToBlob(dataUrl);
       const fileName = `${galleryId}/${crypto.randomUUID()}.${extension}`;
 
+      console.log('[SupabaseService] preparando upload para o Storage', {
+        contentType,
+        fileName,
+      });
+
       const uploadResponse = await this.storageRequest(
         `object/${this.bucketName}/${fileName}`,
         {

--- a/src/utils/convert-to-webp.ts
+++ b/src/utils/convert-to-webp.ts
@@ -1,4 +1,6 @@
-export async function convertToAvif(blob: Blob): Promise<{ blob: Blob; extension: string; mime: string }> {
+const WEBP_MIME = 'image/webp';
+
+export async function convertToWebp(blob: Blob): Promise<{ blob: Blob; extension: string; mime: string }> {
   const fallbackMime = blob.type || 'image/png';
   const fallback = {
     blob,
@@ -23,23 +25,23 @@ export async function convertToAvif(blob: Blob): Promise<{ blob: Blob; extension
 
     context.drawImage(image, 0, 0);
 
-    const avifBlob = await new Promise<Blob | null>(resolve => {
-      canvas.toBlob(resolve, 'image/avif', 0.8);
+    const webpBlob = await new Promise<Blob | null>(resolve => {
+      canvas.toBlob(result => resolve(result), WEBP_MIME, 0.8);
     });
 
-    if (avifBlob && avifBlob.size > 0 && avifBlob.type.includes('avif')) {
-      console.info('[convertToAvif] usando AVIF, tamanho:', avifBlob.size);
+    if (webpBlob && webpBlob.size > 0) {
+      console.info('[convertToWebp] usando WEBP, tamanho:', webpBlob.size);
       return {
-        blob: avifBlob,
-        extension: 'avif',
-        mime: 'image/avif',
+        blob: webpBlob,
+        extension: 'webp',
+        mime: WEBP_MIME,
       };
     }
   } catch (error) {
-    console.warn('Falha ao converter imagem para AVIF', error);
+    console.warn('Falha ao converter imagem para WEBP', error);
   }
 
-  console.warn('[convertToAvif] fallback ativado, mantendo formato original:', fallbackMime);
+  console.warn('[convertToWebp] fallback ativado, mantendo formato original:', fallbackMime);
   return fallback;
 }
 
@@ -59,6 +61,9 @@ async function loadImage(blob: Blob): Promise<HTMLImageElement> {
 }
 
 function detectExtension(mime: string): string {
+  if (mime.includes('webp')) {
+    return 'webp';
+  }
   if (mime.includes('avif')) {
     return 'avif';
   }
@@ -67,9 +72,6 @@ function detectExtension(mime: string): string {
   }
   if (mime.includes('png')) {
     return 'png';
-  }
-  if (mime.includes('webp')) {
-    return 'webp';
   }
   if (mime.includes('gif')) {
     return 'gif';


### PR DESCRIPTION
## Summary
- replace the AVIF conversion helper with a WebP converter that uses canvas.toBlob
- update the webcam capture flow to rely on the WebP blob before emitting the preview
- log the final MIME type and filename before uploading to Supabase Storage with the dynamic content type

## Testing
- npm run lint *(fails: missing script)*
- npm run typecheck *(fails: missing script)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69179f3bbbb0832183a83ad85a5f37e8)