### PR TITLE
Atualiza service worker com caminhos corrigidos de cache

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,10 +1,12 @@
+// O nome do seu repositório no GitHub Pages
+const REPO_NAME = '/angular-kinetic-gallery';
 const CACHE_NAME = 'kinetic-gallery-cache-v1';
 const PRECACHE_URLS = [
-  '/',
-  '/index.html',
-  '/manifest.webmanifest',
-  '/assets/icons/icon-192.svg',
-  '/assets/icons/icon-512.svg'
+  `${REPO_NAME}/`,
+  `${REPO_NAME}/index.html`,
+  `${REPO_NAME}/manifest.webmanifest`,
+  `${REPO_NAME}/assets/icons/icon-192.svg`,
+  `${REPO_NAME}/assets/icons/icon-512.svg`
 ];
 
 self.addEventListener('install', event => {
@@ -41,8 +43,11 @@ self.addEventListener('fetch', event => {
   event.respondWith(
     fetch(event.request)
       .then(response => {
-        const responseClone = response.clone();
-        caches.open(CACHE_NAME).then(cache => cache.put(event.request, responseClone));
+        // Apenas cacheia respostas válidas
+        if (response && response.status === 200) {
+            const responseClone = response.clone();
+            caches.open(CACHE_NAME).then(cache => cache.put(event.request, responseClone));
+        }
         return response;
       })
       .catch(async () => {
@@ -51,8 +56,10 @@ self.addEventListener('fetch', event => {
           return cachedResponse;
         }
 
+        // Se for uma navegação e falhar, sirva o index.html do cache
+        // **AQUI TAMBÉM PRECISA SER CORRIGIDO**
         if (event.request.mode === 'navigate') {
-          return caches.match('/index.html');
+          return caches.match(`${REPO_NAME}/index.html`);
         }
 
         return Response.error();


### PR DESCRIPTION
## Summary
- ajusta o service worker para utilizar caminhos relativos ao repositório no GitHub Pages
- evita armazenar respostas inválidas em cache e referencia corretamente o index.html offline

## Testing
- `npm run lint` *(indisponível: script ausente)*
- `npm run typecheck` *(indisponível: script ausente)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917d58fd84483219da1f82b0699676b)