### PR TITLE
Configura build do Tailwind sem CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="manifest" href="manifest.webmanifest">
   <link rel="apple-touch-icon" sizes="192x192" href="assets/icons/icon-192.svg">
-  <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/gsap.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/CustomEase.min.js"></script>
   <script type="text/javascript">

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+  },
+};

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 /* Add your global styles here */
 
 /* Remove blue default colors and ensure gray theme for dialog elements */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,13 @@
+/** @type {import('tailwindcss').Config} */
+const config = {
+  content: [
+    './index.html',
+    './src/**/*.{html,ts}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- remove o carregamento do Tailwind via CDN do `index.html`
- adiciona as diretivas do Tailwind em `src/styles.css`
- cria as configurações de build locais `tailwind.config.js` e `postcss.config.js`

## Testing
- npm run lint *(falhou: script ausente no projeto)*
- npm run typecheck *(falhou: script ausente no projeto)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917da04b3308321a07bdb2b9ab2f234)