### PR TITLE
Corrige build configurando PostCSS para Tailwind CSS 4

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,0 @@
-// postcss.config.js
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  }
-}

--- a/postcss.config.json
+++ b/postcss.config.json
@@ -1,0 +1,6 @@
+{
+  "plugins": {
+    "@tailwindcss/postcss": {},
+    "autoprefixer": {}
+  }
+}


### PR DESCRIPTION
## Summary
- substitui a configuração JavaScript do PostCSS por uma variante JSON reconhecida pelo Angular CLI
- aponta o PostCSS para o plugin `@tailwindcss/postcss`, garantindo compatibilidade com o Tailwind CSS 4

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917e6f59f08832186068597cf9ebb83)