### PR TITLE
Fix Tailwind PostCSS configuration for Angular build

### DIFF
--- a/postcss.config.json
+++ b/postcss.config.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    ["@tailwindcss/postcss"],
+    ["autoprefixer"]
+  ]
+}


### PR DESCRIPTION
## Summary
- add a JSON PostCSS config so Angular uses the @tailwindcss/postcss plugin with Tailwind CSS v4
- include autoprefixer in the shared PostCSS pipeline to keep generated styles compatible

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917e8c47f448321b2b0b9ae4b82a68a)