### PR TITLE
Ajusta bordas dos cards conforme tema

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -54,7 +54,9 @@
                       class="flex w-full items-center gap-4 rounded-3xl border border-dashed border-white/20 bg-white/5 p-4 text-left transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30"
                       (click)="openGalleryCreationDialogForMobileCapture()"
                       data-cursor-pointer>
-                      <div class="h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl border border-slate-500/40 bg-black/40">
+                      <div
+                        class="h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl border bg-black/40"
+                        [ngClass]="themeService.isDark() ? 'border-black/80' : 'border-white/80'">
                         <div class="flex h-full w-full items-center justify-center text-gray-500">
                           <svg
                             xmlns="http://www.w3.org/2000/svg"
@@ -109,7 +111,9 @@
                       class="flex w-full items-center gap-4 rounded-3xl border border-dashed border-white/20 bg-white/5 p-4 text-left transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/30"
                       (click)="openMobileGalleryPicker()"
                       data-cursor-pointer>
-                      <div class="h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl border border-slate-500/40 bg-black/40">
+                      <div
+                        class="h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl border bg-black/40"
+                        [ngClass]="themeService.isDark() ? 'border-black/80' : 'border-white/80'">
                         <div class="flex h-full w-full items-center justify-center text-gray-500">
                           <svg
                             xmlns="http://www.w3.org/2000/svg"
@@ -291,7 +295,10 @@
                       loading="lazy"
                       class="h-full w-full object-cover transition-transform duration-500 group-active:scale-95 group-hover:scale-[1.03]"
                       alt="Imagem da galeria">
-                    <span class="pointer-events-none absolute inset-0 border border-slate-500/40 mix-blend-screen"></span>
+                    <span
+                      class="pointer-events-none absolute inset-0 border mix-blend-screen"
+                      [ngClass]="themeService.isDark() ? 'border-black/80' : 'border-white/80'"
+                    ></span>
                   </button>
                 }
               </div>
@@ -335,8 +342,7 @@
               <div
                 class="item group absolute overflow-hidden rounded-2xl bg-[#1a1a1a] border transition-[background-color,box-shadow,border-radius] duration-500"
                 [class.rounded-[2.5rem]]="themeService.isLight()"
-                [class.border-slate-500\/40]="themeService.isDark()"
-                [class.border-slate-300\/40]="themeService.isLight()"
+                [ngClass]="themeService.isDark() ? 'border-black/80' : 'border-white/80'"
                 [class.pointer-events-none]="!isInteractionEnabled()"
                 [class.bg-slate-100]="themeService.isLight()"
                 [style.width.px]="item.width"
@@ -416,8 +422,7 @@
           <div
             class="item group absolute overflow-hidden rounded-2xl bg-[#1a1a1a] border transition-[background-color,box-shadow,border-radius] duration-500"
             [class.rounded-[2.5rem]]="themeService.isLight()"
-            [class.border-slate-500\/40]="themeService.isDark()"
-            [class.border-slate-300\/40]="themeService.isLight()"
+            [ngClass]="themeService.isDark() ? 'border-black/80' : 'border-white/80'"
             [class.pointer-events-none]="!isInteractionEnabled()"
             [class.bg-slate-100]="themeService.isLight()"
             [style.width.px]="item.width"

--- a/src/components/mobile-gallery-card/mobile-gallery-card.component.ts
+++ b/src/components/mobile-gallery-card/mobile-gallery-card.component.ts
@@ -1,7 +1,8 @@
-import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { Gallery } from '../../interfaces/gallery.interface';
+import { ThemeService } from '../../services/theme.service';
 
 @Component({
   selector: 'app-mobile-gallery-card',
@@ -9,7 +10,8 @@ import { Gallery } from '../../interfaces/gallery.interface';
   imports: [CommonModule],
   template: `
     <div
-      class="group relative flex w-full items-center gap-4 rounded-3xl border border-slate-500/40 bg-white/5 p-4 transition hover:bg-white/10 focus-within:ring-2 focus-within:ring-white/30"
+      class="group relative flex w-full items-center gap-4 rounded-3xl border bg-white/5 p-4 transition hover:bg-white/10 focus-within:ring-2 focus-within:ring-white/30"
+      [ngClass]="themeService.isDark() ? 'border-black/80' : 'border-white/80'"
       [class.cursor-default]="!selectable()"
       [class.border-emerald-400/80]="showActiveIndicator() && active()"
       [class.ring-2]="showActiveIndicator() && active()"
@@ -17,7 +19,9 @@ import { Gallery } from '../../interfaces/gallery.interface';
       [class.bg-emerald-400/5]="showActiveIndicator() && active()"
       [attr.data-cursor-pointer]="selectable() ? '' : null"
       (click)="handleSelect($event)">
-      <div class="h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl border border-slate-500/40 bg-black/40">
+      <div
+        class="h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl border bg-black/40"
+        [ngClass]="themeService.isDark() ? 'border-black/80' : 'border-white/80'">
         <img
           [src]="coverUrl()"
           class="h-full w-full object-cover"
@@ -75,6 +79,8 @@ export class MobileGalleryCardComponent {
 
   select = output<void>();
   open = output<void>();
+
+  readonly themeService = inject(ThemeService);
 
   handleSelect(event: MouseEvent): void {
     if (!this.selectable()) {


### PR DESCRIPTION
## Summary
- ajusta as bordas dos cards de galeria e fotos para usarem tons escuros no tema dark e claros no tema light
- atualiza o card móvel de galeria para consultar o ThemeService e alinhar a borda ao tema ativo

## Testing
- npm run lint *(fails: Missing script "lint")*
- npm run typecheck *(fails: Missing script "typecheck")*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69186e2eb94c83218dd17a13f80805dc)