### PR TITLE
Ajusta elementos visuais para escala de cinza

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -22,7 +22,12 @@
           isMobileLayout() ? 'rounded-t-3xl rounded-b-none' : 'rounded-full'
         ]">
         <span class="max-w-[10rem] truncate" [title]="authUserEmail() ?? undefined">{{ authUserEmail() }}</span>
-        <span class="rounded-full bg-emerald-500/25 px-2 py-0.5 text-[9px] font-semibold text-emerald-100">Admin</span>
+        <span
+          class="rounded-full px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.24em]"
+          [ngClass]="themeService.isDark() ? 'bg-white/15 text-white/85' : 'bg-slate-200 text-slate-700'"
+        >
+          Admin
+        </span>
         <button
           type="button"
           data-cursor-pointer

--- a/src/components/mobile-gallery-card/mobile-gallery-card.component.ts
+++ b/src/components/mobile-gallery-card/mobile-gallery-card.component.ts
@@ -13,10 +13,13 @@ import { ThemeService } from '../../services/theme.service';
       class="group relative flex w-full items-center gap-4 rounded-3xl border bg-white/5 p-4 transition hover:bg-white/10 focus-within:ring-2 focus-within:ring-white/30"
       [ngClass]="themeService.isDark() ? 'border-black/80' : 'border-white/80'"
       [class.cursor-default]="!selectable()"
-      [class.border-emerald-400/80]="showActiveIndicator() && active()"
+      [class.border-white/80]="showActiveIndicator() && active() && themeService.isDark()"
+      [class.border-slate-500/70]="showActiveIndicator() && active() && themeService.isLight()"
       [class.ring-2]="showActiveIndicator() && active()"
-      [class.ring-emerald-400/40]="showActiveIndicator() && active()"
-      [class.bg-emerald-400/5]="showActiveIndicator() && active()"
+      [class.ring-white/40]="showActiveIndicator() && active() && themeService.isDark()"
+      [class.ring-slate-500/30]="showActiveIndicator() && active() && themeService.isLight()"
+      [class.bg-white/10]="showActiveIndicator() && active() && themeService.isDark()"
+      [class.bg-slate-300/20]="showActiveIndicator() && active() && themeService.isLight()"
       [attr.data-cursor-pointer]="selectable() ? '' : null"
       (click)="handleSelect($event)">
       <div


### PR DESCRIPTION
## Summary
- remove a tonalidade esverdeada da tag de administrador, aplicando variações neutras conforme o tema
- ajusta o indicador de galeria ativa no mobile para usar apenas tons de cinza alinhados com o modo claro/escuro

## Testing
- npm run lint *(falhou: script ausente)*
- npm run typecheck *(falhou: script ausente)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691892cd99388321920ad77cb49503ba)