### PR TITLE
Replace GSAP cursor loop with requestAnimationFrame

### DIFF
--- a/src/services/interactive-cursor.ts
+++ b/src/services/interactive-cursor.ts
@@ -25,6 +25,7 @@ export class InteractiveCursor {
     current: createVec2(window.innerWidth / 2, window.innerHeight / 2),
     lerpAmount: 0.15,
   };
+  private animationFrameId: number | null = null;
   private readonly updateCallback = (): void => this.update();
   private readonly pointerMoveHandler = (event: PointerEvent): void => {
     this.position.target.x = event.clientX;
@@ -65,8 +66,8 @@ export class InteractiveCursor {
   }
 
   private init(): void {
-    gsap.set(this.cursorElement, { xPercent: -50, yPercent: -50 });
-    gsap.ticker.add(this.updateCallback);
+    this.cursorElement.style.transform = 'translate(-50%, -50%)';
+    this.animationFrameId = window.requestAnimationFrame(this.updateCallback);
     document.addEventListener('pointermove', this.pointerMoveHandler);
     document.addEventListener('pointerenter', this.pointerEnterHandler, true);
     document.addEventListener('pointerleave', this.pointerLeaveHandler, true);
@@ -76,14 +77,16 @@ export class InteractiveCursor {
     document.removeEventListener('pointermove', this.pointerMoveHandler);
     document.removeEventListener('pointerenter', this.pointerEnterHandler, true);
     document.removeEventListener('pointerleave', this.pointerLeaveHandler, true);
-    gsap.ticker.remove(this.updateCallback);
+    if (this.animationFrameId !== null) {
+      window.cancelAnimationFrame(this.animationFrameId);
+      this.animationFrameId = null;
+    }
   }
 
   private update(): void {
     this.position.current.lerp(this.position.target, this.position.lerpAmount);
-    gsap.set(this.cursorElement, {
-      x: this.position.current.x,
-      y: this.position.current.y,
-    });
+    const { x, y } = this.position.current;
+    this.cursorElement.style.transform = `translate(${x}px, ${y}px) translate(-50%, -50%)`;
+    this.animationFrameId = window.requestAnimationFrame(this.updateCallback);
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -56,6 +56,7 @@ body,
     transition-timing-function: cubic-bezier(0.19, 1, 0.22, 1);
     opacity: 1;
     will-change: transform, width, height;
+    transform: translate(-50%, -50%);
   }
 
   .custom-cursor.pointer-hover {


### PR DESCRIPTION
## Summary
- replace the GSAP ticker-driven cursor updates with a requestAnimationFrame loop in the interactive cursor service
- track and cancel the pending animation frame when destroying the cursor instance
- add a CSS transform fallback so the cursor remains centered without GSAP helpers

## Testing
- npm run lint *(fails: Missing script "lint")*
- npm run typecheck *(fails: Missing script "typecheck")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918ccd853988321a3fc8fabd9c6c9ac)