### PR TITLE
Atualiza shell da aplicação para usar tokens de tema

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="manifest" href="manifest.webmanifest">
   <link rel="apple-touch-icon" sizes="192x192" href="assets/icons/icon-192.svg">
-  <script src="https://cdn.tailwindcss.com"></script>
   <script type="text/javascript">
     (function () {
       var clarityOptOut = false;
@@ -52,68 +51,6 @@
       })(window, document, "clarity", "script", "tzisvdqjwu");
     })();
   </script>
-  <style>
-    body {
-      background-color: #000000;
-      color: #ffffff;
-      overflow: hidden;
-      position: relative;
-    }
-
-    /* Animated noise effect */
-    body::before {
-      content: "";
-      position: fixed;
-      top: -50%;
-      left: -50%;
-      width: 200%;
-      height: 200%;
-      background: transparent
-        url("https://assets.iceable.com/img/noise-transparent.png") repeat 0 0;
-      background-size: 300px 300px;
-      animation: noise-animation 0.3s steps(5) infinite;
-      opacity: 0.9;
-      will-change: transform;
-      z-index: 100;
-      pointer-events: none;
-    }
-
-    @keyframes noise-animation {
-      0% {
-        transform: translate(0, 0);
-      }
-      10% {
-        transform: translate(-2%, -3%);
-      }
-      20% {
-        transform: translate(-4%, 2%);
-      }
-      30% {
-        transform: translate(2%, -4%);
-      }
-      40% {
-        transform: translate(-2%, 5%);
-      }
-      50% {
-        transform: translate(-4%, 2%);
-      }
-      60% {
-        transform: translate(3%, 0);
-      }
-      70% {
-        transform: translate(0, 3%);
-      }
-      80% {
-        transform: translate(-3%, 0);
-      }
-      90% {
-        transform: translate(2%, 2%);
-      }
-      100% {
-        transform: translate(1%, 0);
-      }
-    }
-  </style>
 <script type="importmap">
 {
   "imports": {
@@ -134,7 +71,7 @@
 }
 </script>
 </head>
-<body class="antialiased font-sans bg-black text-gray-300">
+<body class="app-shell">
   <div class="custom-cursor" aria-hidden="true"></div>
   <app-root></app-root>
 </body>

--- a/src/services/theme.service.ts
+++ b/src/services/theme.service.ts
@@ -163,10 +163,19 @@ export class ThemeService {
   private applyToDocument(theme: ThemeMode): void {
     const body = this.documentRef.body;
     body.dataset.theme = theme;
+    this.documentRef.documentElement.dataset.theme = theme;
+
     const palette = this.palettes[theme];
+    const computedStyles = this.documentRef.defaultView?.getComputedStyle(body) ?? null;
+    const themeColorFromTokens = computedStyles
+      ?.getPropertyValue('--color-bg-canvas')
+      .trim();
     const metaTheme = this.documentRef.querySelector('meta[name="theme-color"]');
     if (metaTheme) {
-      metaTheme.setAttribute('content', palette.metaThemeColor);
+      const themeColor = themeColorFromTokens && themeColorFromTokens.length > 0
+        ? themeColorFromTokens
+        : palette.metaThemeColor;
+      metaTheme.setAttribute('content', themeColor);
     }
   }
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -11,12 +11,36 @@ html, body {
 body {
   margin: 0;
   min-height: 100%;
-  background-color: var(--surface-body);
-  color: var(--text-body);
+  background-color: var(--color-bg-canvas, var(--surface-body));
+  color: var(--color-fg-canvas, var(--text-body));
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   transition: background-color 200ms ease, color 200ms ease;
+}
+
+body.app-shell {
+  background-color: var(--color-bg-canvas, var(--surface-body));
+  color: var(--color-fg-canvas, var(--text-body));
+  overflow: hidden;
+  position: relative;
+}
+
+body.app-shell::before {
+  content: '';
+  position: fixed;
+  inset: -50%;
+  width: 200%;
+  height: 200%;
+  background-image: var(--texture-noise-image);
+  background-repeat: repeat;
+  background-size: var(--texture-noise-size);
+  opacity: var(--texture-noise-opacity);
+  animation: noise-animation var(--texture-noise-speed) steps(5) infinite;
+  will-change: transform;
+  z-index: 100;
+  pointer-events: none;
+  mix-blend-mode: var(--texture-noise-blend-mode);
 }
 
 body[data-theme='dark'] {
@@ -107,6 +131,42 @@ body[data-theme='light'] {
 body,
 [data-theme] [data-cursor-pointer] {
   cursor: auto;
+}
+
+@keyframes noise-animation {
+  0% {
+    transform: translate(0, 0);
+  }
+  10% {
+    transform: translate(-2%, -3%);
+  }
+  20% {
+    transform: translate(-4%, 2%);
+  }
+  30% {
+    transform: translate(2%, -4%);
+  }
+  40% {
+    transform: translate(-2%, 5%);
+  }
+  50% {
+    transform: translate(-4%, 2%);
+  }
+  60% {
+    transform: translate(3%, 0);
+  }
+  70% {
+    transform: translate(0, 3%);
+  }
+  80% {
+    transform: translate(-3%, 0);
+  }
+  90% {
+    transform: translate(2%, 2%);
+  }
+  100% {
+    transform: translate(1%, 0);
+  }
 }
 
 @media (pointer: fine) {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -2,6 +2,13 @@
   /* Base layout tokens */
   --surface-body: #000000;
   --text-body: #e5e7eb;
+  --color-bg-canvas: var(--surface-body);
+  --color-fg-canvas: var(--text-body);
+  --texture-noise-image: url('https://assets.iceable.com/img/noise-transparent.png');
+  --texture-noise-size: 300px 300px;
+  --texture-noise-opacity: 0.9;
+  --texture-noise-speed: 0.3s;
+  --texture-noise-blend-mode: normal;
   --overlay-scrim: rgba(0, 0, 0, 0.7);
 
   /* Context menu tokens */
@@ -59,12 +66,16 @@
   --border-overlay-10: rgba(255, 255, 255, 0.1);
   --shadow-strong: rgba(0, 0, 0, 0.4);
   --cursor-accent: #ffffff;
-  --meta-theme-color: #000000;
+  --meta-theme-color: var(--color-bg-canvas);
 }
 
 [data-theme='light'] {
   --surface-body: #f8fafc;
   --text-body: #0f172a;
+  --color-bg-canvas: var(--surface-body);
+  --color-fg-canvas: var(--text-body);
+  --texture-noise-opacity: 0.35;
+  --texture-noise-blend-mode: soft-light;
   --overlay-scrim: rgba(15, 23, 42, 0.45);
 
   --context-menu-background: rgba(255, 255, 255, 0.98);
@@ -117,5 +128,5 @@
   --border-overlay-10: rgba(148, 163, 184, 0.3);
   --shadow-strong: rgba(148, 163, 184, 0.35);
   --cursor-accent: #0f172a;
-  --meta-theme-color: #f8fafc;
+  --meta-theme-color: var(--color-bg-canvas);
 }


### PR DESCRIPTION
## Summary
- remove o carregamento global do Tailwind via CDN e usa uma classe semântica para o body na shell
- move o ruído animado e cores de fundo para tokens e estilos base compartilhados
- sincroniza o meta theme-color com os tokens consumidos pelo ThemeService

## Testing
- npm run lint *(fails: missing script)*
- npm run typecheck *(fails: missing script)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918da97ef6483218a941e4f8105a289)