### PR TITLE
Refatora diálogos para componentes modais reutilizáveis

### DIFF
--- a/src/components/gallery-creation-dialog/gallery-creation-dialog.component.ts
+++ b/src/components/gallery-creation-dialog/gallery-creation-dialog.component.ts
@@ -1,7 +1,8 @@
-import { Component, Output, EventEmitter, inject } from '@angular/core';
+import { Component, Output, EventEmitter, inject, ElementRef, ViewChild, AfterViewInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { ThemeService } from '../../services/theme.service';
+import { cycleFocus, focusFirstElement } from '../../utils/focus-trap';
 
 @Component({
   selector: 'app-gallery-creation-dialog',
@@ -9,81 +10,86 @@ import { ThemeService } from '../../services/theme.service';
   imports: [CommonModule, ReactiveFormsModule],
   template: `
     <div
-      class="fixed inset-0 flex justify-center items-center z-[10000]"
+      class="modal"
+      tabindex="-1"
       data-cursor-pointer
       [style.backgroundColor]="themeService.scrimColor()"
-      (click)="onClose()">
-      <div
-        class="backdrop-blur-sm rounded-lg p-6 shadow-2xl w-full max-w-lg animate-slide-up relative"
-        [style.backgroundColor]="themeService.dialogPalette().surface"
-        [style.border]="'1px solid ' + themeService.dialogPalette().border"
-        [style.color]="themeService.dialogPalette().text"
-        [style.--dialog-focus-ring]="themeService.dialogPalette().focusRing"
-        (click)="$event.stopPropagation()">
-
-        <div class="flex justify-between items-center mb-4">
-          <h2
-            class="text-xl font-medium tracking-wider"
-            [style.color]="themeService.dialogPalette().title">
-            Criar Galeria
-          </h2>
+      (click)="onClose()"
+    >
+      <article
+        #panel
+        class="modal__panel modal__panel--medium animate-slide-up"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="gallery-creation-title"
+        [style.--modal-surface]="themeService.dialogPalette().surface"
+        [style.--modal-border]="themeService.dialogPalette().border"
+        [style.--modal-text]="themeService.dialogPalette().text"
+        [style.--modal-title]="themeService.dialogPalette().title"
+        [style.--modal-muted]="themeService.dialogPalette().muted"
+        [style.--modal-icon]="themeService.dialogPalette().icon"
+        [style.--input-background]="themeService.dialogPalette().inputBackground"
+        [style.--input-text]="themeService.dialogPalette().inputText"
+        [style.--input-border]="themeService.dialogPalette().inputBorder"
+        [style.--input-focus-ring]="themeService.dialogPalette().focusRing"
+        [style.--btn-primary-bg]="themeService.dialogPalette().buttonPrimaryBg"
+        [style.--btn-primary-text]="themeService.dialogPalette().buttonPrimaryText"
+        [style.--btn-secondary-bg]="themeService.dialogPalette().buttonSecondaryBg"
+        [style.--btn-secondary-text]="themeService.dialogPalette().buttonSecondaryText"
+        [style.--btn-disabled-bg]="themeService.dialogPalette().disabledBg"
+        [style.--btn-disabled-text]="themeService.dialogPalette().disabledText"
+        (click)="$event.stopPropagation()"
+        (keydown)="handleKeydown($event)"
+      >
+        <header class="modal__header">
+          <h2 id="gallery-creation-title" class="modal__title">Criar Galeria</h2>
           <button
-            (click)="onClose()"
+            #closeButton
+            type="button"
+            class="btn btn--ghost btn--icon modal__close"
+            aria-label="Fechar"
             data-cursor-pointer
-            class="text-2xl leading-none rounded-sm focus:outline-none"
-            [style.color]="themeService.dialogPalette().icon"
-            style="background: none; border: none; padding: 0; cursor: pointer;">
+            (click)="onClose()"
+          >
             &times;
           </button>
-        </div>
+        </header>
 
         <form [formGroup]="galleryForm" (ngSubmit)="onSubmit()">
-          <div class="mb-4">
-            <label
-              for="name"
-              class="block text-sm font-medium mb-2 tracking-wider"
-              [style.color]="themeService.dialogPalette().muted">Nome</label>
-            <input
-              id="name"
-              type="text"
-              formControlName="name"
-              class="w-full rounded-md py-3 px-4 focus:outline-none"
-              [style.backgroundColor]="themeService.dialogPalette().inputBackground"
-              [style.color]="themeService.dialogPalette().inputText"
-              [style.border]="'1px solid ' + themeService.dialogPalette().inputBorder"
-              style="outline: none;"
-              placeholder="Digite o nome da galeria"
-              required>
-          </div>
+          <section class="modal__body">
+            <div class="form-field">
+              <label for="name" class="form-label">Nome</label>
+              <input
+                #nameField
+                id="name"
+                type="text"
+                formControlName="name"
+                class="input"
+                placeholder="Digite o nome da galeria"
+                required
+              />
+            </div>
 
-          <div class="mb-6">
-            <label
-              for="description"
-              class="block text-sm font-medium mb-2 tracking-wider"
-              [style.color]="themeService.dialogPalette().muted">Descrição</label>
-            <textarea
-              id="description"
-              formControlName="description"
-              rows="3"
-              class="w-full rounded-md py-3 px-4 focus:outline-none"
-              [style.backgroundColor]="themeService.dialogPalette().inputBackground"
-              [style.color]="themeService.dialogPalette().inputText"
-              [style.border]="'1px solid ' + themeService.dialogPalette().inputBorder"
-              style="outline: none;"
-              placeholder="Digite a descrição da galeria"
-              required>
-            </textarea>
-          </div>
+            <div class="form-field">
+              <label for="description" class="form-label">Descrição</label>
+              <textarea
+                id="description"
+                formControlName="description"
+                rows="3"
+                class="textarea"
+                placeholder="Digite a descrição da galeria"
+                required
+              ></textarea>
+            </div>
+          </section>
 
-          <div class="flex justify-end gap-3">
+          <footer class="modal__footer">
             <button
               type="button"
               (click)="onClose()"
               data-cursor-pointer
-              class="px-6 py-2 font-bold rounded-md transition-all duration-300 tracking-wider text-sm focus:outline-none"
-              [style.backgroundColor]="themeService.dialogPalette().buttonSecondaryBg"
-              [style.color]="themeService.dialogPalette().buttonSecondaryText"
-              style="border: none;">
+              class="btn btn--secondary"
+            >
               Cancelar
             </button>
 
@@ -91,40 +97,17 @@ import { ThemeService } from '../../services/theme.service';
               type="submit"
               [disabled]="galleryForm.invalid"
               data-cursor-pointer
-              class="px-6 py-2 font-bold rounded-md transition-all duration-300 tracking-wider text-sm focus:outline-none"
-              [style.backgroundColor]="galleryForm.invalid ? themeService.dialogPalette().disabledBg : themeService.dialogPalette().buttonPrimaryBg"
-              [style.color]="galleryForm.invalid ? themeService.dialogPalette().disabledText : themeService.dialogPalette().buttonPrimaryText"
-              [style.cursor]="galleryForm.invalid ? 'not-allowed' : 'pointer'"
-              style="border: none;">
+              class="btn btn--primary"
+            >
               Criar
             </button>
-          </div>
+          </footer>
         </form>
-      </div>
+      </article>
     </div>
   `,
-  styles: [`
-    .animate-slide-up {
-      animation: slideUp 0.3s ease-out;
-    }
-
-    @keyframes slideUp {
-      from { opacity: 0; transform: translateY(20px); }
-      to { opacity: 1; transform: translateY(0); }
-    }
-
-    button:not(:disabled):hover {
-      filter: brightness(1.05);
-    }
-
-    input:focus,
-    textarea:focus {
-      border-color: var(--dialog-focus-ring) !important;
-      box-shadow: 0 0 0 2px var(--dialog-focus-ring) !important;
-    }
-  `],
 })
-export class GalleryCreationDialogComponent {
+export class GalleryCreationDialogComponent implements AfterViewInit {
   @Output() close = new EventEmitter<void>();
   @Output() save = new EventEmitter<{ name: string, description: string }>();
 
@@ -132,11 +115,35 @@ export class GalleryCreationDialogComponent {
 
   themeService = inject(ThemeService);
 
+  @ViewChild('panel') panel?: ElementRef<HTMLElement>;
+  @ViewChild('nameField') nameField?: ElementRef<HTMLInputElement>;
+  @ViewChild('closeButton') closeButton?: ElementRef<HTMLButtonElement>;
+
   constructor(private fb: FormBuilder) {
     this.galleryForm = this.fb.group({
       name: ['', Validators.required],
       description: ['']
     });
+  }
+
+  ngAfterViewInit(): void {
+    const container = this.panel?.nativeElement;
+    if (!container) {
+      return;
+    }
+
+    focusFirstElement(container, this.nameField?.nativeElement ?? this.closeButton?.nativeElement ?? null);
+  }
+
+  handleKeydown(event: KeyboardEvent): void {
+    const container = this.panel?.nativeElement;
+    if (!container) {
+      return;
+    }
+
+    if (cycleFocus(event, container)) {
+      event.preventDefault();
+    }
   }
 
   onSubmit() {

--- a/src/components/info-dialog/info-dialog.component.ts
+++ b/src/components/info-dialog/info-dialog.component.ts
@@ -1,6 +1,7 @@
-import { Component, ChangeDetectionStrategy, output, inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, output, inject, ElementRef, ViewChild, AfterViewInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ThemeService } from '../../services/theme.service';
+import { cycleFocus, focusFirstElement } from '../../utils/focus-trap';
 
 @Component({
   selector: 'app-info-dialog',
@@ -8,152 +9,306 @@ import { ThemeService } from '../../services/theme.service';
   imports: [CommonModule],
   template: `
     <div
-      class="fixed inset-0 z-[10001] flex flex-col backdrop-blur-md"
-      [style.backgroundColor]="themeService.scrimColor()">
-      <!-- Header with close button -->
-      <div
-        class="flex justify-between items-center p-6 border-b"
-        [style.borderColor]="themeService.dialogPalette().border"
-        [style.backgroundColor]="themeService.theme() === 'dark' ? 'rgba(0,0,0,0.3)' : 'rgba(241,245,249,0.85)'">
-        <h1
-          class="text-lg font-medium uppercase"
-          [style.color]="themeService.dialogPalette().title"
-          style="letter-spacing: 0.2em;">SOBRE O PROJETO</h1>
-        <button
-          (click)="close.emit()"
-          data-cursor-pointer
-          class="text-2xl leading-none rounded-sm focus:outline-none"
-          [style.color]="themeService.dialogPalette().icon"
-          style="background: none; border: none; padding: 0; cursor: pointer; width: 32px; height: 32px; display: flex; align-items: center; justify-content: center;">
-          <span>&times;</span>
-        </button>
-      </div>
-
-      <!-- Content in three columns -->
-      <div
-        class="flex-1 overflow-y-auto p-8"
-        [style.color]="themeService.dialogPalette().text"
-        [style.backgroundColor]="themeService.dialogPalette().surface"
+      class="modal modal--stacked"
+      tabindex="-1"
+      data-cursor-pointer
+      [style.backgroundColor]="themeService.scrimColor()"
+    >
+      <article
+        #panel
+        class="modal__panel modal__panel--full animate-slide-up info-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="info-dialog-title"
+        [style.--modal-surface]="themeService.dialogPalette().surface"
+        [style.--modal-border]="themeService.dialogPalette().border"
+        [style.--modal-text]="themeService.dialogPalette().text"
+        [style.--modal-title]="themeService.dialogPalette().title"
+        [style.--modal-muted]="themeService.dialogPalette().muted"
+        [style.--modal-icon]="themeService.dialogPalette().icon"
+        [style.--badge-background]="themeService.dialogPalette().inputBackground"
+        [style.--badge-text]="themeService.dialogPalette().inputText"
+        [style.--modal-header-surface]="themeService.theme() === 'dark' ? 'rgba(0,0,0,0.3)' : 'rgba(241,245,249,0.85)'"
+        (click)="$event.stopPropagation()"
+        (keydown)="handleKeydown($event)"
       >
-        <div class="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-12">
+        <header class="modal__header modal__header--flush info-dialog__header">
+          <h1 id="info-dialog-title" class="info-dialog__title">SOBRE O PROJETO</h1>
+          <button
+            #closeButton
+            type="button"
+            class="btn btn--ghost btn--icon modal__close"
+            aria-label="Fechar"
+            data-cursor-pointer
+            (click)="close.emit()"
+          >
+            &times;
+          </button>
+        </header>
 
-          <!-- Column 1: Apresentação -->
-          <div class="space-y-4 max-w-xs">
-            <h2
-              class="text-sm font-medium uppercase mb-4"
-              [style.color]="themeService.dialogPalette().title"
-              style="letter-spacing: 0.15em;">Apresentação</h2>
-            <div class="space-y-3 leading-relaxed" [style.color]="themeService.dialogPalette().text">
-              <p>
-                O Angular Kinetic Gallery é uma galeria de fotos interativa desenvolvida com Angular,
-                oferecendo uma experiência única de navegação e visualização de imagens.
-              </p>
-              <p>
-                Este projeto permite criar múltiplas galerias personalizadas, capturar fotos diretamente 
-                da câmera do dispositivo, e organizar suas imagens em uma interface cinética e dinâmica.
-              </p>
-              <p>
-                Todas as fotos são capturadas em formato quadrado (1:1) e convertidas automaticamente 
-                para preto e branco, criando uma estética minimalista e elegante.
-              </p>
-              <p>
-                Os dados são armazenados localmente no navegador, garantindo privacidade e acesso
-                rápido às suas galerias.
-              </p>
-            </div>
-          </div>
-
-          <!-- Column 2: Comandos -->
-          <div class="space-y-6 max-w-xs">
-            <h2
-              class="text-sm font-medium uppercase mb-4"
-              [style.color]="themeService.dialogPalette().title"
-              style="letter-spacing: 0.15em;">Comandos e Atalhos</h2>
-            <div class="space-y-4" [style.color]="themeService.dialogPalette().text">
-              <div>
-                <h3 class="text-sm font-medium mb-2" [style.color]="themeService.dialogPalette().title">Navegação</h3>
-                <ul class="space-y-2 text-sm">
-                  <li><span class="font-mono px-2 py-1 rounded" [style.backgroundColor]="themeService.dialogPalette().inputBackground" [style.color]="themeService.dialogPalette().inputText">↑</span> - Mover para cima</li>
-                  <li><span class="font-mono px-2 py-1 rounded" [style.backgroundColor]="themeService.dialogPalette().inputBackground" [style.color]="themeService.dialogPalette().inputText">↓</span> - Mover para baixo</li>
-                  <li><span class="font-mono px-2 py-1 rounded" [style.backgroundColor]="themeService.dialogPalette().inputBackground" [style.color]="themeService.dialogPalette().inputText">←</span> - Mover para esquerda</li>
-                  <li><span class="font-mono px-2 py-1 rounded" [style.backgroundColor]="themeService.dialogPalette().inputBackground" [style.color]="themeService.dialogPalette().inputText">→</span> - Mover para direita</li>
-                </ul>
-              </div>
-
-              <div>
-                <h3 class="text-sm font-medium mb-2" [style.color]="themeService.dialogPalette().title">Ações</h3>
-                <ul class="space-y-2 text-sm">
-                  <li><span class="font-mono px-2 py-1 rounded" [style.backgroundColor]="themeService.dialogPalette().inputBackground" [style.color]="themeService.dialogPalette().inputText">Espaço</span> - Criar galeria (na view de galerias) ou capturar foto (na view de fotos)</li>
-                  <li><span class="font-mono px-2 py-1 rounded" [style.backgroundColor]="themeService.dialogPalette().inputBackground" [style.color]="themeService.dialogPalette().inputText">T</span> - Alternar tema claro/escuro</li>
-                  <li><span class="font-mono px-2 py-1 rounded" [style.backgroundColor]="themeService.dialogPalette().inputBackground" [style.color]="themeService.dialogPalette().inputText">R</span> - Ativar/desativar timer na câmera</li>
-                  <li><span class="font-mono px-2 py-1 rounded" [style.backgroundColor]="themeService.dialogPalette().inputBackground" [style.color]="themeService.dialogPalette().inputText">F</span> - Alternar tela cheia</li>
-                  <li><span class="font-mono px-2 py-1 rounded" [style.backgroundColor]="themeService.dialogPalette().inputBackground" [style.color]="themeService.dialogPalette().inputText">ESC</span> - Fechar diálogos ou sair de tela cheia</li>
-                  <li><span class="font-mono px-2 py-1 rounded" [style.backgroundColor]="themeService.dialogPalette().inputBackground" [style.color]="themeService.dialogPalette().inputText">I</span> - Abrir esta janela de informações</li>
-                </ul>
-              </div>
-
-              <div>
-                <h3 class="text-sm font-medium mb-2" [style.color]="themeService.dialogPalette().title">Mouse</h3>
-                <ul class="space-y-2 text-sm">
-                  <li>Clique direito - Abrir menu de contexto</li>
-                  <li>Arrastar - Mover pela galeria (quando habilitado)</li>
-                  <li>Clique em galeria - Visualizar fotos da galeria</li>
-                  <li>Clique em foto - Expandir foto</li>
-                </ul>
-              </div>
-
-            </div>
-          </div>
-
-          <!-- Column 3: Autor -->
-          <div class="space-y-4 max-w-xs">
-            <h2
-              class="text-sm font-medium uppercase mb-4"
-              [style.color]="themeService.dialogPalette().title"
-              style="letter-spacing: 0.15em;">Autor</h2>
-            <div class="space-y-4" [style.color]="themeService.dialogPalette().text">
-              <div>
-                <p class="text-lg font-medium mb-2" [style.color]="themeService.dialogPalette().title">Bolívar Alencastro</p>
-                <p class="text-sm mb-4">Product Designer</p>
-              </div>
-
-              <div>
-              <a
-                href="https://www.linkedin.com/in/bolivaralencastro/"
-                target="_blank"
-                rel="noopener noreferrer"
-                data-cursor-pointer
-                class="inline-flex items-center gap-2 transition-colors"
-                [style.color]="themeService.dialogPalette().title"
-                style="text-decoration: none;">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
-                    <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
-                  </svg>
-                  <span>LinkedIn</span>
-                </a>
-              </div>
-
-              <div class="pt-4 border-t" [style.borderColor]="themeService.dialogPalette().border">
-                <p class="text-xs" [style.color]="themeService.dialogPalette().muted">
-                  © 2024 Bolívar Alencastro. Todos os direitos reservados.
+        <main class="modal__body modal__body--padded info-dialog__body">
+          <div class="info-dialog__grid">
+            <section class="info-dialog__column">
+              <h2 class="info-dialog__section-title">Apresentação</h2>
+              <div class="info-dialog__text">
+                <p>
+                  O Angular Kinetic Gallery é uma galeria de fotos interativa desenvolvida com Angular,
+                  oferecendo uma experiência única de navegação e visualização de imagens.
+                </p>
+                <p>
+                  Este projeto permite criar múltiplas galerias personalizadas, capturar fotos diretamente
+                  da câmera do dispositivo, e organizar suas imagens em uma interface cinética e dinâmica.
+                </p>
+                <p>
+                  Todas as fotos são capturadas em formato quadrado (1:1) e convertidas automaticamente
+                  para preto e branco, criando uma estética minimalista e elegante.
+                </p>
+                <p>
+                  Os dados são armazenados localmente no navegador, garantindo privacidade e acesso
+                  rápido às suas galerias.
                 </p>
               </div>
-            </div>
-          </div>
+            </section>
 
-        </div>
-      </div>
+            <section class="info-dialog__column">
+              <h2 class="info-dialog__section-title">Comandos e Atalhos</h2>
+              <div class="info-dialog__stack">
+                <div>
+                  <h3 class="info-dialog__list-title">Navegação</h3>
+                  <ul class="info-dialog__list">
+                    <li><span class="badge badge--mono">↑</span> Mover para cima</li>
+                    <li><span class="badge badge--mono">↓</span> Mover para baixo</li>
+                    <li><span class="badge badge--mono">←</span> Mover para esquerda</li>
+                    <li><span class="badge badge--mono">→</span> Mover para direita</li>
+                  </ul>
+                </div>
+
+                <div>
+                  <h3 class="info-dialog__list-title">Ações</h3>
+                  <ul class="info-dialog__list">
+                    <li><span class="badge badge--mono">Espaço</span> Criar galeria (na view de galerias) ou capturar foto (na view de fotos)</li>
+                    <li><span class="badge badge--mono">T</span> Alternar tema claro/escuro</li>
+                    <li><span class="badge badge--mono">R</span> Ativar/desativar timer na câmera</li>
+                    <li><span class="badge badge--mono">F</span> Alternar tela cheia</li>
+                    <li><span class="badge badge--mono">ESC</span> Fechar diálogos ou sair de tela cheia</li>
+                    <li><span class="badge badge--mono">I</span> Abrir esta janela de informações</li>
+                  </ul>
+                </div>
+
+                <div>
+                  <h3 class="info-dialog__list-title">Mouse</h3>
+                  <ul class="info-dialog__list">
+                    <li>Clique direito - Abrir menu de contexto</li>
+                    <li>Arrastar - Mover pela galeria (quando habilitado)</li>
+                    <li>Clique em galeria - Visualizar fotos da galeria</li>
+                    <li>Clique em foto - Expandir foto</li>
+                  </ul>
+                </div>
+              </div>
+            </section>
+
+            <section class="info-dialog__column">
+              <h2 class="info-dialog__section-title">Autor</h2>
+              <div class="info-dialog__text info-dialog__text--stacked">
+                <div>
+                  <p class="info-dialog__highlight">Bolívar Alencastro</p>
+                  <p class="info-dialog__muted">Product Designer</p>
+                </div>
+
+                <div>
+                  <a
+                    href="https://www.linkedin.com/in/bolivaralencastro/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-cursor-pointer
+                    class="info-dialog__link"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" class="info-dialog__icon" fill="currentColor" viewBox="0 0 24 24">
+                      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+                    </svg>
+                    <span>LinkedIn</span>
+                  </a>
+                </div>
+
+                <footer class="info-dialog__footer" [style.borderColor]="themeService.dialogPalette().border">
+                  <p class="info-dialog__footnote" [style.color]="themeService.dialogPalette().muted">
+                    © 2024 Bolívar Alencastro. Todos os direitos reservados.
+                  </p>
+                </footer>
+              </div>
+            </section>
+          </div>
+        </main>
+      </article>
     </div>
   `,
   styles: [`
-    button[style*="color"]:hover {
-      filter: brightness(1.1);
+    :host {
+      display: contents;
+    }
+
+    .info-dialog__header {
+      align-items: center;
+    }
+
+    .info-dialog__title {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 600;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: var(--modal-title, var(--dialog-title));
+    }
+
+    .info-dialog__body {
+      background-color: var(--modal-surface, var(--dialog-surface));
+      color: var(--modal-text, var(--dialog-text));
+    }
+
+    .info-dialog__grid {
+      display: grid;
+      gap: 3rem;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      max-width: 80rem;
+      margin: 0 auto;
+    }
+
+    .info-dialog__column {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+      max-width: 22rem;
+    }
+
+    .info-dialog__section-title {
+      margin: 0;
+      font-size: 0.85rem;
+      font-weight: 600;
+      letter-spacing: 0.15em;
+      text-transform: uppercase;
+      color: var(--modal-title, var(--dialog-title));
+    }
+
+    .info-dialog__text {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      line-height: 1.7;
+      font-size: 0.95rem;
+    }
+
+    .info-dialog__text--stacked {
+      gap: 1.5rem;
+    }
+
+    .info-dialog__highlight {
+      margin: 0 0 0.5rem 0;
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: var(--modal-title, var(--dialog-title));
+    }
+
+    .info-dialog__muted {
+      margin: 0;
+      font-size: 0.85rem;
+      color: var(--modal-muted, var(--dialog-muted));
+    }
+
+    .info-dialog__stack {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    .info-dialog__list-title {
+      margin: 0 0 0.75rem 0;
+      font-size: 0.85rem;
+      font-weight: 600;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--modal-title, var(--dialog-title));
+    }
+
+    .info-dialog__list {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      font-size: 0.9rem;
+    }
+
+    .info-dialog__list .badge {
+      margin-right: 0.75rem;
+    }
+
+    .info-dialog__link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: var(--modal-title, var(--dialog-title));
+      text-decoration: none;
+      transition: color 0.2s ease;
+    }
+
+    .info-dialog__link:hover {
+      color: var(--modal-text, var(--dialog-text));
+    }
+
+    .info-dialog__icon {
+      width: 1.25rem;
+      height: 1.25rem;
+    }
+
+    .info-dialog__footer {
+      margin-top: 1.5rem;
+      padding-top: 1rem;
+      border-top: 1px solid var(--modal-border, var(--dialog-border));
+    }
+
+    .info-dialog__footnote {
+      margin: 0;
+      font-size: 0.75rem;
+    }
+
+    @media (max-width: 768px) {
+      .info-dialog__grid {
+        gap: 2.25rem;
+      }
+
+      .info-dialog__column {
+        max-width: none;
+      }
     }
   `],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class InfoDialogComponent {
+export class InfoDialogComponent implements AfterViewInit {
   close = output<void>();
   themeService = inject(ThemeService);
+
+  @ViewChild('panel') panel?: ElementRef<HTMLElement>;
+  @ViewChild('closeButton') closeButton?: ElementRef<HTMLButtonElement>;
+
+  ngAfterViewInit(): void {
+    const container = this.panel?.nativeElement;
+    if (!container) {
+      return;
+    }
+
+    focusFirstElement(container, this.closeButton?.nativeElement ?? null);
+  }
+
+  handleKeydown(event: KeyboardEvent): void {
+    const container = this.panel?.nativeElement;
+    if (!container) {
+      return;
+    }
+
+    if (cycleFocus(event, container)) {
+      event.preventDefault();
+    }
+  }
 }
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,4 +1,5 @@
 @import './tokens.css';
+@import './components/modal.css';
 
 *, *::before, *::after {
   box-sizing: border-box;

--- a/src/styles/components/modal.css
+++ b/src/styles/components/modal.css
@@ -1,0 +1,258 @@
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background-color: transparent;
+  z-index: 10000;
+  outline: none;
+}
+
+.modal--stacked {
+  align-items: stretch;
+  justify-content: flex-start;
+  padding: 0;
+  backdrop-filter: blur(12px);
+}
+
+.modal__panel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: min(100%, 32rem);
+  max-height: 90vh;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  background-color: var(--modal-surface, var(--dialog-surface));
+  border: 1px solid var(--modal-border, var(--dialog-border));
+  color: var(--modal-text, var(--dialog-text));
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(8px);
+}
+
+.modal__panel--full {
+  width: 100%;
+  max-width: none;
+  height: 100%;
+  max-height: none;
+  border-radius: 0;
+  padding: 0;
+}
+
+.modal__panel--medium {
+  width: min(100%, 34rem);
+}
+
+.modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 1rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 1px solid var(--modal-border, var(--dialog-border));
+}
+
+.modal__header--flush {
+  padding: 1.5rem;
+  margin: 0;
+  border-bottom: 1px solid var(--modal-border, var(--dialog-border));
+  background-color: var(--modal-header-surface, transparent);
+}
+
+.modal__title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--modal-title, var(--dialog-title));
+}
+
+.modal__body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.modal__body--padded {
+  padding: 1.5rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.form-field:last-of-type {
+  margin-bottom: 0;
+}
+
+.form-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--modal-muted, var(--dialog-muted));
+}
+
+.modal__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding-top: 1.5rem;
+  margin-top: 1.5rem;
+  border-top: 1px solid var(--modal-border, var(--dialog-border));
+}
+
+.modal__footer--separated {
+  padding: 1.5rem;
+  margin: 0;
+}
+
+.modal__footer--split {
+  justify-content: space-between;
+  align-items: center;
+}
+
+.modal__footer-group {
+  display: inline-flex;
+  gap: 0.75rem;
+}
+
+.modal__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  color: var(--modal-icon, var(--dialog-icon));
+}
+
+.btn {
+  --btn-bg: var(--color-button-primary-bg);
+  --btn-text: var(--color-button-primary-text);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid transparent;
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  background-color: var(--btn-bg);
+  color: var(--btn-text);
+  cursor: pointer;
+  transition: filter 0.2s ease, transform 0.2s ease;
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--input-focus-ring, var(--dialog-focus-ring));
+  outline-offset: 2px;
+}
+
+.btn:not(:disabled):hover {
+  filter: brightness(1.05);
+}
+
+.btn:not(:disabled):active {
+  transform: translateY(1px);
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  background-color: var(--btn-disabled-bg, var(--color-button-disabled-bg));
+  color: var(--btn-disabled-text, var(--color-button-disabled-text));
+  filter: none;
+}
+
+.btn--secondary {
+  --btn-bg: var(--btn-secondary-bg, var(--color-button-secondary-bg));
+  --btn-text: var(--btn-secondary-text, var(--color-button-secondary-text));
+}
+
+.btn--primary {
+  --btn-bg: var(--btn-primary-bg, var(--color-button-primary-bg));
+  --btn-text: var(--btn-primary-text, var(--color-button-primary-text));
+}
+
+.btn--danger {
+  --btn-bg: var(--btn-danger-bg, var(--color-button-danger-bg));
+  --btn-text: var(--btn-danger-text, var(--color-button-danger-text));
+}
+
+.btn--ghost {
+  --btn-bg: transparent;
+  --btn-text: var(--modal-icon, var(--dialog-icon));
+  border-color: transparent;
+}
+
+.btn--icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  border-radius: 0.375rem;
+  font-size: 1.75rem;
+}
+
+.input,
+.textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--input-border, var(--dialog-input-border));
+  background-color: var(--input-background, var(--dialog-input-background));
+  color: var(--input-text, var(--dialog-input-text));
+  font: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input:focus,
+.textarea:focus {
+  outline: none;
+  border-color: var(--input-focus-ring, var(--dialog-focus-ring));
+  box-shadow: 0 0 0 2px var(--input-focus-ring, var(--dialog-focus-ring));
+}
+
+.input--error,
+.textarea--error {
+  border-color: var(--input-error-border, var(--color-input-error-border));
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  background-color: var(--badge-background, var(--color-badge-bg));
+  color: var(--badge-text, var(--color-badge-text));
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.badge--mono {
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', ui-monospace, 'Source Code Pro', monospace;
+  letter-spacing: 0.15em;
+}
+
+.animate-slide-up {
+  animation: modal-slide-up 0.3s ease-out;
+}
+
+@keyframes modal-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -41,6 +41,22 @@
   --dialog-timer-inactive-bg: rgb(38, 38, 38);
   --dialog-timer-inactive-text: rgb(180, 180, 180);
 
+  /* Dialog state tokens */
+  --color-button-primary-bg: var(--dialog-button-primary-bg);
+  --color-button-primary-text: var(--dialog-button-primary-text);
+  --color-button-secondary-bg: var(--dialog-button-secondary-bg);
+  --color-button-secondary-text: var(--dialog-button-secondary-text);
+  --color-button-danger-bg: #962828;
+  --color-button-danger-text: #ffffff;
+  --color-button-disabled-bg: var(--dialog-disabled-bg);
+  --color-button-disabled-text: var(--dialog-disabled-text);
+  --color-input-error-border: #ff6b6b;
+  --color-badge-bg: var(--dialog-input-background);
+  --color-badge-text: var(--dialog-input-text);
+  --color-timer-active-bg: var(--dialog-timer-active-bg);
+  --color-timer-inactive-bg: var(--dialog-timer-inactive-bg);
+  --color-timer-inactive-text: var(--dialog-timer-inactive-text);
+
   /* Frequently reused background tokens */
   --surface-neutral-strong: #000000;
   --surface-neutral-60: rgba(0, 0, 0, 0.6);
@@ -105,6 +121,21 @@
   --dialog-timer-active-bg: #0f172a;
   --dialog-timer-inactive-bg: rgba(148, 163, 184, 0.25);
   --dialog-timer-inactive-text: #475569;
+
+  --color-button-primary-bg: var(--dialog-button-primary-bg);
+  --color-button-primary-text: var(--dialog-button-primary-text);
+  --color-button-secondary-bg: var(--dialog-button-secondary-bg);
+  --color-button-secondary-text: var(--dialog-button-secondary-text);
+  --color-button-danger-bg: #b91c1c;
+  --color-button-danger-text: #f8fafc;
+  --color-button-disabled-bg: var(--dialog-disabled-bg);
+  --color-button-disabled-text: var(--dialog-disabled-text);
+  --color-input-error-border: #f87171;
+  --color-badge-bg: var(--dialog-input-background);
+  --color-badge-text: var(--dialog-input-text);
+  --color-timer-active-bg: var(--dialog-timer-active-bg);
+  --color-timer-inactive-bg: var(--dialog-timer-inactive-bg);
+  --color-timer-inactive-text: var(--dialog-timer-inactive-text);
 
   --surface-neutral-strong: #f8fafc;
   --surface-neutral-60: rgba(15, 23, 42, 0.12);

--- a/src/utils/focus-trap.ts
+++ b/src/utils/focus-trap.ts
@@ -1,0 +1,53 @@
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])'
+].join(',');
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  const nodes = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+  return nodes.filter(element => !element.hasAttribute('inert') && !element.closest('[inert]'));
+}
+
+export function focusFirstElement(container: HTMLElement, fallback?: HTMLElement | null): void {
+  const focusable = getFocusableElements(container);
+  const target = focusable[0] ?? fallback ?? null;
+
+  if (target) {
+    setTimeout(() => target.focus());
+  }
+}
+
+export function cycleFocus(event: KeyboardEvent, container: HTMLElement): boolean {
+  if (event.key !== 'Tab') {
+    return false;
+  }
+
+  if (typeof document === 'undefined') {
+    return false;
+  }
+
+  const focusable = getFocusableElements(container);
+  if (focusable.length === 0) {
+    return false;
+  }
+
+  const active = document.activeElement as HTMLElement | null;
+  const currentIndex = active ? focusable.indexOf(active) : -1;
+  const goingBackwards = event.shiftKey;
+
+  let nextIndex: number;
+  if (currentIndex === -1) {
+    nextIndex = goingBackwards ? focusable.length - 1 : 0;
+  } else if (goingBackwards) {
+    nextIndex = currentIndex === 0 ? focusable.length - 1 : currentIndex - 1;
+  } else {
+    nextIndex = currentIndex === focusable.length - 1 ? 0 : currentIndex + 1;
+  }
+
+  focusable[nextIndex].focus();
+  return true;
+}


### PR DESCRIPTION
## Summary
- substitui os diálogos de criação, edição e informações para usar o layout semântico com classes `.modal`, `.btn`, `.input` e `.badge`
- adiciona estilos compartilhados de modal, tokens de estado e utilitário de foco para garantir transições e acessibilidade por teclado
- atualiza os tokens globais para mapear estados de botão, badge e timer a variáveis reutilizáveis

## Testing
- npm run lint *(fails: Missing script: "lint")*
- npm run typecheck *(fails: Missing script: "typecheck")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918dbe8f0108321ae908e01cf8c3e4d)