### PR TITLE
Atualizar estilos de card e menu

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -623,7 +623,6 @@
     [y]="contextMenu().y"
     [isFullscreen]="isFullscreen()"
     [groups]="contextMenu().groups"
-    [themePalette]="themeService.contextMenuPalette()"
     [themeMode]="themeService.theme()"
     [isAutoNavigationActive]="isAutoNavigationActive()"
     [autoNavigationCountdown]="autoNavigationCountdown()"

--- a/src/components/context-menu/context-menu.component.ts
+++ b/src/components/context-menu/context-menu.component.ts
@@ -1,7 +1,7 @@
-import { Component, ChangeDetectionStrategy, input, output, signal } from '@angular/core';
+import { Component, ChangeDetectionStrategy, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ContextMenuGroup, ContextMenuAction } from '../../types/context-menu';
-import { ContextMenuPalette, ThemeMode } from '../../services/theme.service';
+import { ThemeMode } from '../../services/theme.service';
 
 @Component({
   selector: 'app-context-menu',
@@ -9,145 +9,129 @@ import { ContextMenuPalette, ThemeMode } from '../../services/theme.service';
   imports: [CommonModule],
   template: `
     <div
-      class="fixed backdrop-blur-sm rounded-md shadow-lg p-1 z-50 animate-fade-in text-sm tracking-wider min-w-[220px]"
-      [style.backgroundColor]="themePalette().background"
-      [style.borderColor]="themePalette().border"
-      [style.color]="themePalette().text"
+      class="menu"
       [style.left.px]="x()"
-      [style.top.px]="y()">
-      <ul class="space-y-2" role="menu">
+      [style.top.px]="y()"
+    >
+      <ul class="menu__groups" role="menu">
         @for (group of groups(); track group.label) {
-          <li class="space-y-1" role="none">
-            <p
-              class="px-3 pt-2 text-[10px] font-semibold uppercase tracking-[0.28em]"
-              [style.color]="themePalette().heading">
-              {{ group.label }}
-            </p>
-            <ul class="space-y-1" role="none">
+          <li class="menu__group" role="none">
+            <p class="menu__heading">{{ group.label }}</p>
+            <ul class="menu__items" role="none">
               @for (action of group.actions; track action) {
-                <li
-                  role="menuitem"
-                  tabindex="0"
-                  data-cursor-pointer
-                  class="px-3 py-1.5 rounded-md cursor-pointer flex items-center gap-2.5 focus:outline-none"
-                  style="transition: background-color 0.2s;"
-                  [style.backgroundColor]="hoveredAction() === action ? themePalette().itemHover : 'transparent'"
-                  (mouseenter)="hoveredAction.set(action)"
-                  (mouseleave)="hoveredAction.set(null)"
-                  (focus)="hoveredAction.set(action)"
-                  (blur)="hoveredAction.set(null)"
-                  (click)="handleAction(action, $event)"
-                  (keydown.enter)="handleAction(action, $event)">
-                  <ng-container [ngSwitch]="action">
-                    <ng-container *ngSwitchCase="'toggleTheme'">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" [attr.stroke]="themePalette().icon">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1.5m0 15V21m9-9h-1.5M4.5 12H3m15.364 6.364-1.06-1.06M6.697 6.697 5.636 5.636m12.728 0-1.06 1.06M6.697 17.303l-1.061 1.061M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
-                      </svg>
-                      <span>{{ themeMode() === 'dark' ? 'Ativar modo claro' : 'Ativar modo escuro' }}</span>
-                    </ng-container>
-                    <ng-container *ngSwitchCase="'togglePlayback'">
-                      @if (isAutoNavigationActive()) {
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          class="h-4 w-4"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke-width="1.5"
-                          stroke="currentColor"
-                          [attr.stroke]="themePalette().icon"
-                        >
-                          <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 6h-3A1.5 1.5 0 0 0 6 7.5v9A1.5 1.5 0 0 0 7.5 18h3A1.5 1.5 0 0 0 12 16.5v-9A1.5 1.5 0 0 0 10.5 6Zm7.5 1.5v9A1.5 1.5 0 0 1 16.5 18h-3a1.5 1.5 0 0 1-1.5-1.5v-9A1.5 1.5 0 0 1 13.5 6h3A1.5 1.5 0 0 1 18 7.5Z" />
-                        </svg>
-                        <span>Parar navegação automática</span>
-                      } @else {
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          class="h-4 w-4"
-                          fill="currentColor"
-                          viewBox="0 0 24 24"
-                          [attr.fill]="themePalette().icon"
-                        >
-                          <path d="M5.25 5.653c0-1.44 1.585-2.294 2.8-1.509l8.087 5.094a1.8 1.8 0 0 1 0 3.024L8.05 17.357c-1.215.785-2.8-.07-2.8-1.51V5.653Z" />
-                        </svg>
-                        <span>
-                          @if (autoNavigationCountdown() !== null) {
-                            Iniciar navegação automática ({{ autoNavigationCountdown() }}s)
+                <li role="none">
+                  <button
+                    type="button"
+                    class="menu__item"
+                    role="menuitem"
+                    data-cursor-pointer
+                    (click)="handleAction(action, $event)"
+                  >
+                    <span class="menu__icon" aria-hidden="true">
+                      <ng-container [ngSwitch]="action">
+                        <ng-container *ngSwitchCase="'toggleTheme'">
+                          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1.5m0 15V21m9-9h-1.5M4.5 12H3m15.364 6.364-1.06-1.06M6.697 6.697 5.636 5.636m12.728 0-1.06 1.06M6.697 17.303l-1.061 1.061M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+                          </svg>
+                        </ng-container>
+                        <ng-container *ngSwitchCase="'togglePlayback'">
+                          @if (isAutoNavigationActive()) {
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke-width="1.5"
+                              stroke="currentColor"
+                            >
+                              <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 6h-3A1.5 1.5 0 0 0 6 7.5v9A1.5 1.5 0 0 0 7.5 18h3A1.5 1.5 0 0 0 12 16.5v-9A1.5 1.5 0 0 0 10.5 6Zm7.5 1.5v9A1.5 1.5 0 0 1 16.5 18h-3a1.5 1.5 0 0 1-1.5-1.5v-9A1.5 1.5 0 0 1 13.5 6h3A1.5 1.5 0 0 1 18 7.5Z" />
+                            </svg>
                           } @else {
-                            Iniciar navegação automática
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              fill="currentColor"
+                              viewBox="0 0 24 24"
+                            >
+                              <path d="M5.25 5.653c0-1.44 1.585-2.294 2.8-1.509l8.087 5.094a1.8 1.8 0 0 1 0 3.024L8.05 17.357c-1.215.785-2.8-.07-2.8-1.51V5.653Z" />
+                            </svg>
                           }
-                        </span>
-                      }
-                    </ng-container>
-                    <ng-container *ngSwitchCase="'toggleFullscreen'">
-                      @if (isFullscreen()) {
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" [attr.stroke]="themePalette().icon">
-                          <path stroke-linecap="round" stroke-linejoin="round" d="M9 9V4.5M9 9H4.5M9 9 3.75 3.75M9 15v4.5M9 15H4.5M9 15l-5.25 5.25M15 9h4.5M15 9V4.5M15 9l5.25-5.25M15 15h4.5M15 15v4.5M15 15l5.25 5.25" />
-                        </svg>
-                        <span>Sair da tela cheia</span>
-                      } @else {
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" [attr.stroke]="themePalette().icon">
-                          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9M20.25 20.25h-4.5m4.5 0v-4.5m0 4.5L15 15" />
-                        </svg>
-                        <span>Entrar em tela cheia</span>
-                      }
-                    </ng-container>
-                    <ng-container *ngSwitchCase="'info'">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" [attr.stroke]="themePalette().icon">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
-                      </svg>
-                      <span>Informações</span>
-                    </ng-container>
-                    <ng-container *ngSwitchCase="'createGallery'">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" [attr.stroke]="themePalette().icon">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-                      </svg>
-                      <span>Criar galeria</span>
-                    </ng-container>
-                    <ng-container *ngSwitchCase="'capturePhoto'">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" [attr.stroke]="themePalette().icon">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M6.827 6.175A2.31 2.31 0 0 1 5.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 0 0-1.134-.175 2.31 2.31 0 0 1-1.64-1.055l-.822-1.316a2.192 2.192 0 0 0-1.736-1.039 48.774 48.774 0 0 0-5.232 0 2.192 2.192 0 0 0-1.736 1.039l-.821 1.316Z" />
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 12.75a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0ZM18.75 10.5h.008v.008h-.008V10.5Z" />
-                      </svg>
-                      <span>Tirar foto</span>
-                    </ng-container>
-                    <ng-container *ngSwitchCase="'editGallery'">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" [attr.stroke]="themePalette().icon">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14.125V21H4.875c-.621 0-1.125-.504-1.125-1.125V4.875c0-.621.504-1.125 1.125-1.125H12" />
-                      </svg>
-                      <span>Editar galeria</span>
-                    </ng-container>
-                    <ng-container *ngSwitchCase="'deleteGallery'">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" [attr.stroke]="themePalette().icon">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.107H7.218a2.25 2.25 0 01-2.244-2.107L4.74 5.836m19.825 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zM12 4.5V3.75c0-.621-.504-1.125-1.125-1.125H9.75A1.125 1.125 0 008.625 3.75v.75m-8.1 4.5H12m-.75 0h-.75m.75 0h-.75M12 4.5H5.25m-1.5 0h-.75M4.5 4.5V2.25m0 0H2.25M2.25 2.25V4.5m0 0h-.75m.75 0v.75m0 0H2.25V4.5m-1.5 0h-.75M2.25 4.5V2.25M2.25 4.5h-.75m.75 0v.75m0 0H4.5m-.75 0V2.25M12 4.5h-.75m.75 0h-.75M12 4.5V3.75c0-.621-.504-1.125-1.125-1.125H9.75A1.125 1.125 0 008.625 3.75v.75m-8.1 4.5H12m-.75 0h-.75m.75 0h-.75Z" />
-                      </svg>
-                      <span>Excluir galeria</span>
-                    </ng-container>
-                  </ng-container>
+                        </ng-container>
+                        <ng-container *ngSwitchCase="'toggleFullscreen'">
+                          @if (isFullscreen()) {
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                              <path stroke-linecap="round" stroke-linejoin="round" d="M9 9V4.5M9 9H4.5M9 9 3.75 3.75M9 15v4.5M9 15H4.5M9 15l-5.25 5.25M15 9h4.5M15 9V4.5M15 9l5.25-5.25M15 15h4.5M15 15v4.5M15 15l5.25 5.25" />
+                            </svg>
+                          } @else {
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9M20.25 20.25h-4.5m4.5 0v-4.5m0 4.5L15 15" />
+                            </svg>
+                          }
+                        </ng-container>
+                        <ng-container *ngSwitchCase="'info'">
+                          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
+                          </svg>
+                        </ng-container>
+                        <ng-container *ngSwitchCase="'createGallery'">
+                          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                          </svg>
+                        </ng-container>
+                        <ng-container *ngSwitchCase="'capturePhoto'">
+                          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M6.827 6.175A2.31 2.31 0 0 1 5.186 7.23c-.38.054-.757.112-1.134.175C2.999 7.58 2.25 8.507 2.25 9.574V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9.574c0-1.067-.75-1.994-1.802-2.169a47.865 47.865 0 0 0-1.134-.175 2.31 2.31 0 0 1-1.64-1.055l-.822-1.316a2.192 2.192 0 0 0-1.736-1.039 48.774 48.774 0 0 0-5.232 0 2.192 2.192 0 0 0-1.736 1.039l-.821 1.316Z" />
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 12.75a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0ZM18.75 10.5h.008v.008h-.008V10.5Z" />
+                          </svg>
+                        </ng-container>
+                        <ng-container *ngSwitchCase="'editGallery'">
+                          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14.125V21H4.875c-.621 0-1.125-.504-1.125-1.125V4.875c0-.621.504-1.125 1.125-1.125H12" />
+                          </svg>
+                        </ng-container>
+                        <ng-container *ngSwitchCase="'deleteGallery'">
+                          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.107H7.218a2.25 2.25 0 01-2.244-2.107L4.74 5.836m19.825 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zM12 4.5V3.75c0-.621-.504-1.125-1.125-1.125H9.75A1.125 1.125 0 008.625 3.75v.75m-8.1 4.5H12m-.75 0h-.75m.75 0h-.75M12 4.5H5.25m-1.5 0h-.75M4.5 4.5V2.25m0 0H2.25M2.25 2.25V4.5m0 0h-.75m.75 0v.75m0 0H2.25V4.5m-1.5 0h-.75M2.25 4.5V2.25M2.25 4.5h-.75m.75 0v.75m0 0H4.5m-.75 0V2.25M12 4.5h-.75m.75 0h-.75M12 4.5V3.75c0-.621-.504-1.125-1.125-1.125H9.75A1.125 1.125 0 008.625 3.75v.75m-8.1 4.5H12m-.75 0h-.75m.75 0h-.75Z" />
+                          </svg>
+                        </ng-container>
+                      </ng-container>
+                    </span>
+                    <span class="menu__label">
+                      <ng-container [ngSwitch]="action">
+                        <ng-container *ngSwitchCase="'toggleTheme'">
+                          {{ themeMode() === 'dark' ? 'Ativar modo claro' : 'Ativar modo escuro' }}
+                        </ng-container>
+                        <ng-container *ngSwitchCase="'togglePlayback'">
+                          @if (isAutoNavigationActive()) {
+                            Parar navegação automática
+                          } @else {
+                            @if (autoNavigationCountdown() !== null) {
+                              Iniciar navegação automática ({{ autoNavigationCountdown() }}s)
+                            } @else {
+                              Iniciar navegação automática
+                            }
+                          }
+                        </ng-container>
+                        <ng-container *ngSwitchCase="'toggleFullscreen'">
+                          {{ isFullscreen() ? 'Sair da tela cheia' : 'Entrar em tela cheia' }}
+                        </ng-container>
+                        <ng-container *ngSwitchCase="'info'">Informações</ng-container>
+                        <ng-container *ngSwitchCase="'createGallery'">Criar galeria</ng-container>
+                        <ng-container *ngSwitchCase="'capturePhoto'">Tirar foto</ng-container>
+                        <ng-container *ngSwitchCase="'editGallery'">Editar galeria</ng-container>
+                        <ng-container *ngSwitchCase="'deleteGallery'">Excluir galeria</ng-container>
+                      </ng-container>
+                    </span>
+                  </button>
                 </li>
               }
             </ul>
             @if (!$last) {
-              <div class="mx-2 h-px" [style.backgroundColor]="themePalette().divider"></div>
+              <div class="menu__divider" role="presentation"></div>
             }
           </li>
         }
       </ul>
     </div>
   `,
-  styles: [`
-    .animate-fade-in {
-      animation: fadeIn 0.1s ease-out;
-    }
-
-    @keyframes fadeIn {
-      from { opacity: 0; transform: scale(0.95); }
-      to { opacity: 1; transform: scale(1); }
-    }
-    
-    li[role="menuitem"]:focus {
-      outline: none;
-    }
-  `],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ContextMenuComponent {
@@ -155,12 +139,9 @@ export class ContextMenuComponent {
   y = input.required<number>();
   isFullscreen = input<boolean>(false);
   groups = input.required<ContextMenuGroup[]>();
-  themePalette = input.required<ContextMenuPalette>();
   themeMode = input.required<ThemeMode>();
   isAutoNavigationActive = input<boolean>(false);
   autoNavigationCountdown = input<number | null>(null);
-
-  hoveredAction = signal<ContextMenuAction | null>(null);
 
   close = output<void>();
   capture = output<void>();

--- a/src/components/mobile-gallery-card/mobile-gallery-card.component.ts
+++ b/src/components/mobile-gallery-card/mobile-gallery-card.component.ts
@@ -1,51 +1,42 @@
-import { ChangeDetectionStrategy, Component, inject, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { Gallery } from '../../interfaces/gallery.interface';
-import { ThemeService } from '../../services/theme.service';
 
 @Component({
   selector: 'app-mobile-gallery-card',
   standalone: true,
   imports: [CommonModule],
   template: `
-    <div
-      class="group relative flex w-full items-center gap-4 rounded-3xl border bg-white/5 p-4 transition hover:bg-white/10 focus-within:ring-2 focus-within:ring-white/30"
-      [ngClass]="themeService.isDark() ? 'border-black/80' : 'border-white/80'"
-      [class.cursor-default]="!selectable()"
-      [class.border-white/80]="showActiveIndicator() && active() && themeService.isDark()"
-      [class.border-slate-500/70]="showActiveIndicator() && active() && themeService.isLight()"
-      [class.ring-2]="showActiveIndicator() && active()"
-      [class.ring-white/40]="showActiveIndicator() && active() && themeService.isDark()"
-      [class.ring-slate-500/30]="showActiveIndicator() && active() && themeService.isLight()"
-      [class.bg-white/10]="showActiveIndicator() && active() && themeService.isDark()"
-      [class.bg-slate-300/20]="showActiveIndicator() && active() && themeService.isLight()"
+    <article
+      class="card card--gallery"
+      [class.is-selectable]="selectable()"
+      [class.is-active]="showActiveIndicator() && active()"
       [attr.data-cursor-pointer]="selectable() ? '' : null"
       (click)="handleSelect($event)">
-      <div
-        class="h-16 w-16 flex-shrink-0 overflow-hidden rounded-2xl border bg-black/40"
-        [ngClass]="themeService.isDark() ? 'border-black/80' : 'border-white/80'">
+      <div class="card__avatar">
         <img
           [src]="coverUrl()"
-          class="h-full w-full object-cover"
+          class="card__image"
           loading="lazy"
           [attr.alt]="'Prévia da galeria ' + gallery().name" />
       </div>
-      <div class="min-w-0 flex-1">
-        <h3 class="truncate text-base font-semibold text-white">{{ gallery().name }}</h3>
-        <p class="mt-1 truncate text-xs text-gray-400">
+      <div class="card__content">
+        <h3 class="card__title">{{ gallery().name }}</h3>
+        <p class="card__description">
           {{ gallery().description || 'Sem descrição' }}
         </p>
-        <div class="mt-2 flex flex-wrap items-center gap-3 text-[11px] uppercase tracking-[0.24em] text-gray-500">
+        <div class="card__meta">
           @if (gallery().createdAt) {
-            <span>{{ gallery().createdAt }}</span>
+            <span class="badge badge--mono card__badge">{{ gallery().createdAt }}</span>
           }
-          <span>{{ gallery().imageUrls.length }} fotos</span>
+          <span class="badge badge--mono card__badge">{{ gallery().imageUrls.length }} fotos</span>
         </div>
       </div>
       <button
         type="button"
-        class="rounded-full border border-white/20 p-3 text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
+        class="card__action"
+        data-cursor-pointer
         [attr.aria-label]="viewLabel()"
         (click)="handleOpen($event)">
         <svg
@@ -53,7 +44,9 @@ import { ThemeService } from '../../services/theme.service';
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 24 24"
           fill="none"
-          class="h-5 w-5">
+          class="card__action-icon"
+          role="img"
+        >
           <path
             stroke="currentColor"
             stroke-linecap="round"
@@ -68,7 +61,7 @@ import { ThemeService } from '../../services/theme.service';
             d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
         </svg>
       </button>
-    </div>
+    </article>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -82,8 +75,6 @@ export class MobileGalleryCardComponent {
 
   select = output<void>();
   open = output<void>();
-
-  readonly themeService = inject(ThemeService);
 
   handleSelect(event: MouseEvent): void {
     if (!this.selectable()) {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,5 +1,7 @@
 @import './tokens.css';
 @import './components/modal.css';
+@import './components/card.css';
+@import './components/menu.css';
 
 *, *::before, *::after {
   box-sizing: border-box;

--- a/src/styles/components/card.css
+++ b/src/styles/components/card.css
@@ -1,0 +1,125 @@
+@import '../tokens.css';
+
+.card {
+  position: relative;
+  display: flex;
+  width: 100%;
+  border-radius: 1.5rem;
+  border: 1px solid var(--card-border);
+  background-color: var(--card-background);
+  color: var(--card-text, inherit);
+  transition:
+    background-color var(--card-transition),
+    border-color var(--card-transition),
+    box-shadow var(--card-transition),
+    transform var(--card-transition);
+}
+
+.card--gallery {
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.card.is-selectable {
+  cursor: pointer;
+}
+
+.card.is-selectable:active {
+  transform: scale(0.995);
+}
+
+.card:hover {
+  background-color: var(--card-hover-background);
+}
+
+.card:focus-within {
+  box-shadow: 0 0 0 2px var(--card-focus-ring);
+}
+
+.card.is-active {
+  border-color: var(--card-active-border);
+  background-color: var(--card-active-background);
+  box-shadow: 0 0 0 2px var(--card-active-ring);
+}
+
+.card__avatar {
+  width: 4rem;
+  height: 4rem;
+  flex-shrink: 0;
+  border-radius: 1.25rem;
+  border: 1px solid var(--card-avatar-border);
+  background-color: var(--card-avatar-background);
+  overflow: hidden;
+}
+
+.card__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.card__content {
+  min-width: 0;
+  flex: 1;
+}
+
+.card__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--card-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.card__description {
+  margin: 0.25rem 0 0;
+  font-size: 0.75rem;
+  color: var(--card-muted-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.card__meta {
+  margin-top: 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.card__badge {
+  letter-spacing: 0.2em;
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+}
+
+.card__action {
+  border-radius: 999px;
+  border: 1px solid var(--card-action-border);
+  padding: 0.65rem;
+  background-color: var(--card-action-background);
+  color: var(--card-action-icon);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition:
+    background-color var(--card-transition),
+    border-color var(--card-transition),
+    color var(--card-transition);
+}
+
+.card__action:hover,
+.card__action:focus-visible {
+  background-color: var(--card-action-hover-background);
+  outline: none;
+}
+
+.card__action-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+}

--- a/src/styles/components/menu.css
+++ b/src/styles/components/menu.css
@@ -1,0 +1,106 @@
+@import '../tokens.css';
+
+.menu {
+  position: fixed;
+  min-width: 220px;
+  padding: 0.5rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--context-menu-border);
+  background-color: var(--context-menu-background);
+  color: var(--context-menu-text);
+  backdrop-filter: blur(12px);
+  font-size: 0.875rem;
+  letter-spacing: 0.05em;
+  z-index: 50;
+  pointer-events: auto;
+  box-shadow: var(--context-menu-shadow);
+  animation: menu-fade-in 0.1s ease-out;
+}
+
+.menu ul,
+.menu li {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.menu__groups {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.menu__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.menu__heading {
+  padding: 0.5rem 0.75rem 0 0.75rem;
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  color: var(--context-menu-heading);
+}
+
+.menu__items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.menu__item {
+  width: 100%;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.45rem 0.75rem;
+  background-color: transparent;
+  color: inherit;
+  font: inherit;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  cursor: pointer;
+  transition: var(--context-menu-transition);
+}
+
+.menu__item:hover,
+.menu__item:focus-visible {
+  background-color: var(--context-menu-item-hover);
+  outline: none;
+}
+
+.menu__icon {
+  display: inline-flex;
+  color: var(--context-menu-icon);
+}
+
+.menu__icon svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.menu__label {
+  flex: 1;
+  text-align: left;
+}
+
+.menu__divider {
+  height: 1px;
+  margin: 0.25rem;
+  background-color: var(--context-menu-divider);
+}
+
+@keyframes menu-fade-in {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -15,10 +15,31 @@
   --context-menu-background: rgba(30, 30, 30, 0.95);
   --context-menu-border: rgb(50, 50, 50);
   --context-menu-item-hover: rgb(60, 60, 60);
+  --context-menu-transition: background-color 150ms ease, color 150ms ease;
   --context-menu-heading: #9ca3af;
   --context-menu-divider: rgba(255, 255, 255, 0.08);
   --context-menu-text: #e5e7eb;
   --context-menu-icon: #9ca3af;
+  --context-menu-shadow: 0 25px 70px rgba(0, 0, 0, 0.55);
+
+  /* Card tokens */
+  --card-background: rgba(255, 255, 255, 0.05);
+  --card-border: rgba(255, 255, 255, 0.12);
+  --card-hover-background: rgba(255, 255, 255, 0.08);
+  --card-active-border: rgba(255, 255, 255, 0.45);
+  --card-active-ring: rgba(255, 255, 255, 0.35);
+  --card-active-background: rgba(255, 255, 255, 0.12);
+  --card-focus-ring: rgba(255, 255, 255, 0.35);
+  --card-text: var(--text-inverse);
+  --card-muted-text: var(--text-gray-400);
+  --card-meta-text: var(--text-gray-500);
+  --card-avatar-border: rgba(255, 255, 255, 0.2);
+  --card-avatar-background: rgba(0, 0, 0, 0.45);
+  --card-action-border: rgba(255, 255, 255, 0.2);
+  --card-action-background: transparent;
+  --card-action-hover-background: rgba(255, 255, 255, 0.08);
+  --card-action-icon: var(--text-inverse);
+  --card-transition: 200ms ease;
 
   /* Dialog tokens */
   --dialog-surface: rgba(30, 30, 30, 0.95);
@@ -97,10 +118,30 @@
   --context-menu-background: rgba(255, 255, 255, 0.98);
   --context-menu-border: rgba(148, 163, 184, 0.5);
   --context-menu-item-hover: rgba(226, 232, 240, 0.9);
+  --context-menu-transition: background-color 150ms ease, color 150ms ease;
   --context-menu-heading: #475569;
   --context-menu-divider: rgba(148, 163, 184, 0.35);
   --context-menu-text: #0f172a;
   --context-menu-icon: #475569;
+  --context-menu-shadow: 0 15px 50px rgba(15, 23, 42, 0.2);
+
+  --card-background: rgba(255, 255, 255, 0.9);
+  --card-border: rgba(148, 163, 184, 0.5);
+  --card-hover-background: rgba(226, 232, 240, 0.7);
+  --card-active-border: rgba(15, 23, 42, 0.55);
+  --card-active-ring: rgba(148, 163, 184, 0.5);
+  --card-active-background: rgba(226, 232, 240, 0.85);
+  --card-focus-ring: rgba(148, 163, 184, 0.4);
+  --card-text: #0f172a;
+  --card-muted-text: #475569;
+  --card-meta-text: #64748b;
+  --card-avatar-border: rgba(148, 163, 184, 0.4);
+  --card-avatar-background: rgba(148, 163, 184, 0.2);
+  --card-action-border: rgba(148, 163, 184, 0.45);
+  --card-action-background: rgba(255, 255, 255, 0.85);
+  --card-action-hover-background: rgba(15, 23, 42, 0.08);
+  --card-action-icon: #0f172a;
+  --card-transition: 200ms ease;
 
   --dialog-surface: rgba(255, 255, 255, 0.98);
   --dialog-border: rgba(148, 163, 184, 0.5);


### PR DESCRIPTION
## Summary
- atualizar o card mobile para usar as novas classes de layout, badges reutilizáveis e estados visuais controlados por CSS
- adicionar folhas de estilo globais para cards e menus, movendo tokens de cor/transição para `tokens.css`
- refatorar o menu contextual para utilizar as classes `.menu`/`.menu__item` e remover dependências de estilos inline

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm run typecheck` *(fails: Missing script "typecheck")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918dea2304c832189a34f9d07d50ef7)