### PR TITLE
feat: modularize app shell styling

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -1,38 +1,25 @@
 <!-- Container principal da galeria com listeners para interação -->
 <div
-  class="relative h-full w-full overflow-hidden select-none transition-colors duration-500"
-  [class.cursor-none]="isIdle() || isAutoNavigationActive()"
-  [class.bg-black]="themeService.isDark()"
-  [class.bg-slate-100]="themeService.isLight()"
-  [class.p-8]="!isMobileLayout()"
+  class="app-shell"
+  [class.is-mobile]="isMobileLayout()"
+  [class.is-idle]="isIdle() || isAutoNavigationActive()"
+  [class.is-fullscreen]="isFullscreen()"
   (contextmenu)="onRightClick($event)">
 
+  <div class="app-shell__viewport">
   @if (canManageContent()) {
     <div
-      class="pointer-events-none z-40 flex flex-col gap-2"
-      [ngClass]="
-        isMobileLayout()
-          ? 'fixed inset-x-0 bottom-0 items-stretch px-4 pb-4'
-          : 'absolute right-4 top-4 items-end sm:right-8 sm:top-8'
-      ">
+      class="app-shell__admin-panel"
+      [class.app-shell__admin-panel--mobile]="isMobileLayout()">
       <div
-        class="pointer-events-auto flex w-full items-center gap-2 border px-4 py-3 text-[10px] font-semibold uppercase tracking-[0.3em] shadow-lg backdrop-blur sm:w-auto"
-        [ngClass]="[
-          themeService.isDark() ? 'border-white/15 bg-black/60 text-white/85' : 'border-slate-300/70 bg-white/80 text-slate-800',
-          isMobileLayout() ? 'rounded-t-3xl rounded-b-none' : 'rounded-full'
-        ]">
-        <span class="max-w-[10rem] truncate" [title]="authUserEmail() ?? undefined">{{ authUserEmail() }}</span>
-        <span
-          class="rounded-full px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.24em]"
-          [ngClass]="themeService.isDark() ? 'bg-white/15 text-white/85' : 'bg-slate-200 text-slate-700'"
-        >
-          Admin
-        </span>
+        class="identity-card"
+        [class.identity-card--mobile]="isMobileLayout()">
+        <span class="identity-card__name" [title]="authUserEmail() ?? undefined">{{ authUserEmail() }}</span>
+        <span class="identity-card__role">Admin</span>
         <button
           type="button"
           data-cursor-pointer
-          class="rounded-full border border-white/20 px-3 py-1 text-[10px] font-semibold tracking-[0.32em] transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
-          [ngClass]="themeService.isDark() ? 'text-white/85' : 'text-slate-800/90 hover:bg-slate-200/60 focus:ring-slate-500/60'"
+          class="identity-card__action"
           (click)="signOut()">
           Sair
         </button>
@@ -289,7 +276,7 @@
                 }
               </div>
             } @else {
-              <div class="mt-8 grid grid-cols-3 gap-x-3 gap-y-5">
+              <div class="mobile-gallery-grid grid-gallery grid-gallery--tight">
                 @for (image of images(); track trackMobileImage($index, image); let index = $index) {
                   <button
                     type="button"
@@ -325,7 +312,7 @@
             <p class="mt-1 text-sm tracking-wider text-gray-500">Clique com o botão direito para criar uma nova galeria.</p>
             <div class="pointer-events-auto mt-4 flex flex-col items-center">
               <p class="mb-3 text-sm text-gray-500">Como tirar uma foto:</p>
-              <div class="flex gap-2">
+              <div class="flow">
                 <button
                   data-cursor-pointer
                   (click)="openGalleryCreationDialog(); $event.stopPropagation();"
@@ -345,42 +332,37 @@
           @for (item of visibleItems(); track trackById($index, item)) {
             @if (item.type === 'gallery') {
               <div
-                class="item group absolute overflow-hidden rounded-2xl bg-[#1a1a1a] border transition-[background-color,box-shadow,border-radius] duration-500"
-                [class.rounded-[2.5rem]]="themeService.isLight()"
-                [ngClass]="themeService.isDark() ? 'border-black/80' : 'border-white/80'"
-                [class.pointer-events-none]="!isInteractionEnabled()"
-                [class.bg-slate-100]="themeService.isLight()"
+                class="gallery-card"
+                [class.gallery-card--light]="themeService.isLight()"
+                [class.is-disabled]="!isInteractionEnabled()"
+                [class.is-interactive]="isInteractionEnabled()"
                 [style.width.px]="item.width"
                 [style.height.px]="item.height"
                 [style.left.px]="item.x"
                 [style.top.px]="item.y"
-                [class.cursor-pointer]="isInteractionEnabled()"
                 [attr.data-cursor-pointer]="isInteractionEnabled() ? '' : null"
                 (click)="selectGallery(item.id)"
                 (mouseenter)="onGalleryHoverStart(item.id, item.previewKey)"
                 (mouseleave)="onGalleryHoverEnd(item.previewKey)"
                 (contextmenu)="onGalleryRightClick($event, item.id)"
               >
-                <div class="item-image-container relative h-full w-full overflow-hidden">
+                <div class="gallery-card__media">
                   <img [src]="galleryPreviewImages()[item.previewKey] ?? item.thumbnailUrl"
-                       class="h-full w-full object-cover pointer-events-none opacity-0 transition-opacity duration-400"
-                       (load)="$event.target.classList.add('opacity-100')"
-                       [class.group-hover:scale-105]="isInteractionEnabled()"
+                       class="gallery-card__image"
+                       (load)="$event.target.classList.add('is-visible')"
                        alt="Capa da Galeria: {{ item.name }}">
                   <div
-                    class="pointer-events-none absolute inset-0 z-10 transition-[box-shadow] duration-500"
-                    [class.shadow-\[inset_0_0_40px_20px_rgba\(0,0,0,0\.8\)\]]="themeService.isDark()"
-                    [class.shadow-\[inset_0_0_28px_18px_rgba\(15,23,42,0\.22\)\]]="themeService.isLight()"
+                    class="gallery-card__overlay"
+                    [class.gallery-card__overlay--dark]="themeService.isDark()"
+                    [class.gallery-card__overlay--light]="themeService.isLight()"
                   ></div>
                 </div>
-                <span
-                  class="pointer-events-none absolute right-2 top-2 z-30 rounded-full bg-black/50 px-1.5 py-0.5 text-[10px] font-semibold text-gray-200 opacity-0 transition-opacity duration-200 group-hover:opacity-100"
-                >
+                <span class="gallery-card__badge">
                   {{ item.creationOrder }}
                 </span>
-                <div class="absolute bottom-0 left-0 pl-8 pb-8 text-white opacity-0 transition-opacity duration-300 group-hover:opacity-100">
-                  <div class="mb-0.5 text-xs text-gray-300">{{ item.createdAt }}</div>
-                  <div class="text-sm font-medium">{{ item.name }}</div>
+                <div class="gallery-card__meta stack stack--tight">
+                  <div class="text-meta">{{ item.createdAt }}</div>
+                  <div class="text-title">{{ item.name }}</div>
                 </div>
               </div>
             }
@@ -400,7 +382,7 @@
             <p class="mt-1 text-sm tracking-wider text-gray-500">Clique com o botão direito para adicionar fotos.</p>
             <div class="mt-4 flex flex-col items-center">
               <p class="mb-3 text-sm text-gray-500">Como tirar uma foto:</p>
-              <div class="flex gap-2">
+              <div class="flow">
                 <button
                   data-cursor-pointer
                   (click)="openWebcamCapture(); $event.stopPropagation();"
@@ -425,36 +407,31 @@
       <div #canvas class="absolute will-change-transform">
         @for (item of visibleItems(); track trackById($index, item)) {
           <div
-            class="item group absolute overflow-hidden rounded-2xl bg-[#1a1a1a] border transition-[background-color,box-shadow,border-radius] duration-500"
-            [class.rounded-[2.5rem]]="themeService.isLight()"
-            [ngClass]="themeService.isDark() ? 'border-black/80' : 'border-white/80'"
-            [class.pointer-events-none]="!isInteractionEnabled()"
-            [class.bg-slate-100]="themeService.isLight()"
+            class="photo-card"
+            [class.photo-card--light]="themeService.isLight()"
+            [class.is-disabled]="!isInteractionEnabled()"
+            [class.is-interactive]="isInteractionEnabled()"
             [style.width.px]="item.width"
             [style.height.px]="item.height"
             [style.left.px]="item.x"
             [style.top.px]="item.y"
-            [class.cursor-pointer]="isInteractionEnabled()"
             [attr.data-cursor-pointer]="isInteractionEnabled() ? '' : null"
             (click)="onImageClick($event, item)"
           >
-            <div class="item-image-container relative h-full w-full overflow-hidden">
+            <div class="photo-card__media">
               @if (item.type === 'photo') {
                 <img [src]="item.url"
-                     class="h-full w-full object-cover pointer-events-none opacity-0 transition-opacity duration-400"
-                     (load)="$event.target.classList.add('opacity-100')"
-                     [class.group-hover:scale-1.05]="isInteractionEnabled()"
+                     class="photo-card__image"
+                     (load)="$event.target.classList.add('is-visible')"
                      alt="Imagem da galeria capturada pela webcam">
               }
               <div
-                class="pointer-events-none absolute inset-0 z-10 transition-[box-shadow] duration-500"
-                [class.shadow-\[inset_0_0_40px_20px_rgba\(0,0,0,0\.8\)\]]="themeService.isDark()"
-                [class.shadow-\[inset_0_0_28px_18px_rgba\(15,23,42,0\.22\)\]]="themeService.isLight()"
+                class="photo-card__overlay"
+                [class.photo-card__overlay--dark]="themeService.isDark()"
+                [class.photo-card__overlay--light]="themeService.isLight()"
               ></div>
             </div>
-            <span
-              class="pointer-events-none absolute right-2 top-2 z-30 rounded-full bg-black/50 px-1.5 py-0.5 text-[10px] font-semibold text-gray-200 opacity-0 transition-opacity duration-200 group-hover:opacity-100"
-            >
+            <span class="photo-card__badge">
               {{ item.creationOrder }}
             </span>
           </div>
@@ -463,15 +440,15 @@
     }
 
     <!-- Relógio e Data -->
-    <div class="pointer-events-none absolute bottom-4 left-4 z-20 text-sm font-mono tracking-widest text-gray-700">
+    <div class="clock">
       {{ currentTime() }}
     </div>
-    <div class="pointer-events-none absolute bottom-4 right-4 z-20 text-sm font-mono tracking-widest text-gray-700">
+    <div class="date-indicator">
       {{ currentDate() }}
     </div>
 
     <!-- Contador de Galerias ou Fotos -->
-    <div class="pointer-events-none absolute top-4 right-4 z-20 text-sm font-mono tracking-widest text-gray-700">
+    <div class="counter">
       @if (currentView() === 'galleries') {
         {{ galleryCounterLabel() }} {{ galleryCount() }}
       } @else {
@@ -483,7 +460,8 @@
       <!-- Botão Voltar para Galerias -->
       <button (click)="backToGalleries()"
               data-cursor-pointer
-              class="absolute left-4 top-4 z-20 rounded-full bg-black/40 p-2 text-white transition hover:bg-black/60 hover:text-gray-300 focus:outline-none">
+              class="app-shell__back-button button button--icon"
+      >
         <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
         </svg>
@@ -493,7 +471,7 @@
 
   @if (isAutoNavigationActive()) {
     <div
-      class="fixed inset-0 z-30 cursor-default pointer-events-auto"
+      class="auto-navigation-shield"
       aria-hidden="true"
       data-auto-navigation-shield
     ></div>
@@ -501,10 +479,9 @@
 
   <!-- Overlay para o modo de visualização expandida -->
   <div
-    class="overlay pointer-events-none fixed inset-0 z-[9999] bg-black/90 transition-opacity duration-500"
-    [class.opacity-100]="!!expandedItem()"
-    [class.opacity-0]="!expandedItem()"
-    [class.pointer-events-auto]="!!expandedItem()"
+    class="screen-overlay"
+    [class.is-visible]="!!expandedItem()"
+    [class.is-hidden]="!expandedItem()"
     data-cursor-pointer
     (click)="closeExpandedItem()"
   ></div>
@@ -512,7 +489,7 @@
   <!-- Elemento para a imagem expandida, renderizado condicionalmente -->
   @if (expandedItem(); as item) {
     <div #expandedItemElement
-      class="fixed top-1/2 left-1/2 z-[10000] flex items-center justify-center overflow-hidden rounded-lg bg-black shadow-2xl"
+      class="screen-overlay__media"
       style="transform: translate(-50%, -50%); will-change: width, height, transform;">
       <img [src]="item.url" class="h-full w-full object-contain pointer-events-none" alt="Imagem expandida">
       @if (isMobileLayout()) {
@@ -548,20 +525,19 @@
 
 <!-- Componentes de UI flutuantes -->
 @if (isLoginDialogVisible()) {
-  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4" (click)="closeLoginDialog()" data-cursor-pointer>
+  <div class="login-dialog" (click)="closeLoginDialog()" data-cursor-pointer>
     <div
-      class="w-full max-w-sm rounded-3xl border px-6 py-8 shadow-2xl backdrop-blur"
-      [ngClass]="themeService.isDark() ? 'border-white/10 bg-black/85 text-white' : 'border-slate-200 bg-white text-slate-900'"
+      class="login-dialog__card"
       (click)="$event.stopPropagation()">
-      <div class="mb-6 flex items-start justify-between">
-        <div>
-          <h2 class="text-lg font-semibold tracking-[0.2em] uppercase">Entrar como administrador</h2>
-          <p class="mt-2 text-xs text-gray-400">Use suas credenciais do Supabase para habilitar as ferramentas de criação.</p>
+      <div class="login-dialog__header">
+        <div class="stack stack--tight">
+          <h2 class="login-dialog__title">Entrar como administrador</h2>
+          <p class="login-dialog__description">Use suas credenciais do Supabase para habilitar as ferramentas de criação.</p>
         </div>
         <button
           type="button"
           data-cursor-pointer
-          class="text-xl"
+          class="button-reset"
           [class.opacity-50]="isLoginInProgress()"
           [disabled]="isLoginInProgress()"
           (click)="closeLoginDialog()">
@@ -570,47 +546,45 @@
       </div>
 
       @if (loginError()) {
-        <div class="mb-4 rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-200">
+        <div class="alert alert--danger">
           {{ loginError() }}
         </div>
       }
 
-      <form (submit)="submitLogin(); $event.preventDefault();" class="space-y-4">
-        <div class="flex flex-col gap-2">
-          <label class="text-xs font-semibold uppercase tracking-[0.28em] text-gray-400">Email</label>
+      <form (submit)="submitLogin(); $event.preventDefault();" class="stack">
+        <div class="form-field">
+          <label class="form-field__label">Email</label>
           <input
             type="email"
             autocomplete="email"
-            class="w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2"
-            [ngClass]="themeService.isDark() ? 'border-white/10 bg-black/40 focus:ring-white/30' : 'border-slate-200 bg-white focus:ring-slate-400'"
+            class="form-field__input"
             [value]="loginEmail()"
             (input)="loginEmail.set($any($event.target).value)"
             [disabled]="isLoginInProgress()"
             required>
         </div>
 
-        <div class="flex flex-col gap-2">
-          <label class="text-xs font-semibold uppercase tracking-[0.28em] text-gray-400">Senha</label>
+        <div class="form-field">
+          <label class="form-field__label">Senha</label>
           <input
             type="password"
             autocomplete="current-password"
-            class="w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2"
-            [ngClass]="themeService.isDark() ? 'border-white/10 bg-black/40 focus:ring-white/30' : 'border-slate-200 bg-white focus:ring-slate-400'"
+            class="form-field__input"
             [value]="loginPassword()"
             (input)="loginPassword.set($any($event.target).value)"
             [disabled]="isLoginInProgress()"
             required>
         </div>
 
-        <div class="flex flex-col gap-2">
+        <div class="stack stack--tight">
           <button
             type="submit"
             data-cursor-pointer
-            class="w-full rounded-lg bg-indigo-500 px-4 py-2 text-sm font-semibold uppercase tracking-[0.3em] text-white transition hover:bg-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-300 disabled:cursor-not-allowed disabled:opacity-60"
+            class="button button--primary button--block"
             [disabled]="isLoginInProgress()">
             @if (isLoginInProgress()) { Entrando... } @else { Entrar }
           </button>
-          <p class="text-[10px] uppercase tracking-[0.28em] text-gray-500">Apenas contas autorizadas podem gerenciar galerias.</p>
+          <p class="form-hint">Apenas contas autorizadas podem gerenciar galerias.</p>
         </div>
       </form>
     </div>
@@ -639,7 +613,7 @@
 }
 
 @if (isWebcamVisible() && canManageContent()) {
-  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75" (click)="isWebcamVisible.set(false)" data-cursor-pointer>
+  <div class="overlay-panel" (click)="isWebcamVisible.set(false)" data-cursor-pointer>
     <app-webcam-capture
       [captureAllowed]="canManageContent()"
       (capture)="onCaptureComplete($event)"
@@ -668,3 +642,4 @@
     (close)="isInfoDialogVisible.set(false)">
   </app-info-dialog>
 }
+</div>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -2,6 +2,7 @@
 @import './components/modal.css';
 @import './components/card.css';
 @import './components/menu.css';
+@import './components/app-shell.css';
 
 *, *::before, *::after {
   box-sizing: border-box;

--- a/src/styles/components/app-shell.css
+++ b/src/styles/components/app-shell.css
@@ -1,0 +1,664 @@
+:root {
+  --app-shell-spacing-xs: 0.5rem;
+  --app-shell-spacing-sm: 0.75rem;
+  --app-shell-spacing-md: 1.25rem;
+  --app-shell-spacing-lg: 2rem;
+  --app-shell-toolbar-radius: 999px;
+  --app-shell-panel-radius: 1.5rem;
+  --app-shell-border: rgba(255, 255, 255, 0.15);
+  --app-shell-border-light: rgba(15, 23, 42, 0.15);
+  --app-shell-panel-bg: rgba(8, 8, 8, 0.65);
+  --app-shell-panel-bg-light: rgba(255, 255, 255, 0.85);
+  --app-shell-panel-text: rgba(255, 255, 255, 0.9);
+  --app-shell-panel-text-light: rgba(15, 23, 42, 0.8);
+  --app-shell-muted-text: var(--text-gray-400);
+  --app-shell-muted-text-light: #475569;
+  --app-shell-danger: #f87171;
+  --app-shell-surface: rgba(15, 23, 42, 0.35);
+}
+
+body[data-theme='light'] {
+  --app-shell-border: rgba(148, 163, 184, 0.4);
+  --app-shell-panel-bg: rgba(248, 250, 252, 0.85);
+  --app-shell-panel-text: #0f172a;
+  --app-shell-muted-text: #475569;
+  --app-shell-surface: rgba(226, 232, 240, 0.85);
+}
+
+.app-shell {
+  position: relative;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+  padding: var(--app-shell-spacing-lg);
+  transition: background-color 400ms ease, color 400ms ease;
+  touch-action: none;
+  user-select: none;
+}
+
+.app-shell.is-mobile {
+  padding: 0;
+}
+
+.app-shell.is-idle {
+  cursor: none;
+}
+
+.app-shell__viewport {
+  position: relative;
+  height: 100%;
+  width: 100%;
+}
+
+.app-shell__admin-panel {
+  position: absolute;
+  top: var(--app-shell-spacing-lg);
+  right: var(--app-shell-spacing-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--app-shell-spacing-sm);
+  z-index: 40;
+  pointer-events: none;
+}
+
+.app-shell__admin-panel.app-shell__admin-panel--mobile {
+  position: fixed;
+  inset-inline: 0;
+  bottom: 0;
+  top: auto;
+  padding: 0 var(--app-shell-spacing-md) var(--app-shell-spacing-md);
+  align-items: stretch;
+}
+
+.identity-card {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--app-shell-spacing-sm);
+  width: max-content;
+  border-radius: var(--app-shell-toolbar-radius);
+  border: 1px solid var(--app-shell-border);
+  background-color: var(--app-shell-panel-bg);
+  color: var(--app-shell-panel-text);
+  padding: var(--app-shell-spacing-sm) var(--app-shell-spacing-md);
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  box-shadow: 0 25px 60px rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(14px);
+}
+
+.identity-card.identity-card--mobile {
+  border-radius: 1.5rem 1.5rem 0 0;
+  width: 100%;
+  justify-content: space-between;
+}
+
+.identity-card__name {
+  font-size: 0.9rem;
+  letter-spacing: normal;
+  text-transform: none;
+  max-width: 12rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.identity-card__role {
+  border-radius: 999px;
+  padding: 0.1rem 0.75rem;
+  background-color: var(--surface-overlay-20);
+  color: inherit;
+  font-size: 0.55rem;
+}
+
+.identity-card__action {
+  border-radius: var(--app-shell-toolbar-radius);
+  border: 1px solid currentColor;
+  padding: 0.35rem 1rem;
+  background: transparent;
+  color: inherit;
+  letter-spacing: 0.32em;
+  font-size: 0.6rem;
+  cursor: pointer;
+  transition: background-color 200ms ease, color 200ms ease;
+}
+
+.identity-card__action:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+.identity-card__action:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+body[data-theme='light'] .identity-card__action:hover {
+  background-color: rgba(15, 23, 42, 0.1);
+}
+
+.mobile-shell {
+  min-height: 100vh;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  color: var(--text-inverse);
+  background-color: #000;
+}
+
+body[data-theme='light'] .mobile-shell {
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+.mobile-shell__header,
+.mobile-shell__content {
+  padding-inline: 1.5rem;
+}
+
+.mobile-shell__header {
+  padding-block: 2rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.3em;
+  color: var(--text-gray-400);
+}
+
+.mobile-shell__content {
+  flex: 1;
+  overflow-y: auto;
+  padding-bottom: 4rem;
+}
+
+.mobile-shell__content--capture {
+  padding-block: 2rem 2.5rem;
+}
+
+.mobile-toolbar {
+  display: flex;
+  gap: 1rem;
+}
+
+.mobile-toolbar__button,
+.button,
+.button-reset {
+  border: none;
+  background: none;
+  font: inherit;
+  color: inherit;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--app-shell-toolbar-radius);
+  padding: 0.45rem 1.2rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  cursor: pointer;
+  transition: background-color 200ms ease, color 200ms ease, box-shadow 200ms ease;
+  border: 1px solid transparent;
+}
+
+.button--ghost {
+  border-color: rgba(255, 255, 255, 0.25);
+  background-color: transparent;
+  color: rgba(255, 255, 255, 0.95);
+}
+
+body[data-theme='light'] .button--ghost {
+  border-color: rgba(148, 163, 184, 0.6);
+  color: #0f172a;
+}
+
+.button--ghost:hover,
+.button--ghost:focus-visible {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+body[data-theme='light'] .button--ghost:hover,
+body[data-theme='light'] .button--ghost:focus-visible {
+  background-color: rgba(15, 23, 42, 0.08);
+}
+
+.button--danger {
+  border-color: transparent;
+  background-color: rgba(239, 68, 68, 0.2);
+  color: #fee2e2;
+}
+
+body[data-theme='light'] .button--danger {
+  color: #991b1b;
+  background-color: rgba(248, 113, 113, 0.2);
+}
+
+.button--primary {
+  background-color: var(--dialog-button-primary-bg);
+  color: var(--dialog-button-primary-text);
+  border-color: transparent;
+}
+
+.button--block {
+  width: 100%;
+}
+
+.button--icon {
+  padding: 0.4rem;
+  border-radius: 999px;
+}
+
+.app-shell__back-button {
+  position: absolute;
+  top: var(--app-shell-spacing-lg);
+  left: var(--app-shell-spacing-lg);
+  z-index: 20;
+  background-color: rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: #fff;
+  border-radius: 999px;
+  transition: background-color 200ms ease, color 200ms ease;
+}
+
+.app-shell__back-button:hover,
+.app-shell__back-button:focus-visible {
+  background-color: rgba(0, 0, 0, 0.65);
+}
+
+body[data-theme='light'] .app-shell__back-button {
+  background-color: rgba(15, 23, 42, 0.08);
+  border-color: rgba(15, 23, 42, 0.15);
+  color: #0f172a;
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--stack-gap, 1rem);
+}
+
+.stack--tight {
+  --stack-gap: 0.5rem;
+}
+
+.stack--loose {
+  --stack-gap: 1.5rem;
+}
+
+.flow {
+  display: flex;
+  align-items: center;
+  gap: var(--flow-gap, 1rem);
+  flex-wrap: wrap;
+}
+
+.flow--nowrap {
+  flex-wrap: nowrap;
+}
+
+.grid-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.25rem 1.5rem;
+}
+
+.grid-gallery--tight {
+  gap: 0.75rem;
+}
+
+.mobile-gallery-grid {
+  margin-top: 2rem;
+}
+
+.gallery-card,
+.photo-card {
+  position: absolute;
+  overflow: hidden;
+  border-radius: 1.5rem;
+  border: 1px solid var(--app-shell-border);
+  background-color: var(--surface-muted);
+  transition: border-radius 400ms ease, box-shadow 400ms ease, background-color 400ms ease;
+}
+
+.gallery-card.is-interactive,
+.photo-card.is-interactive {
+  cursor: pointer;
+}
+
+.gallery-card--light,
+.photo-card--light {
+  border-color: var(--app-shell-border-light);
+  background-color: var(--surface-body);
+  border-radius: 2.5rem;
+}
+
+.gallery-card.is-disabled,
+.photo-card.is-disabled {
+  pointer-events: none;
+}
+
+.gallery-card__image,
+.photo-card__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 500ms ease, opacity 400ms ease;
+  opacity: 0;
+}
+
+.gallery-card__media,
+.photo-card__media {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.gallery-card__image.is-visible,
+.photo-card__image.is-visible {
+  opacity: 1;
+}
+
+.gallery-card:hover .gallery-card__image,
+.photo-card:hover .photo-card__image {
+  transform: scale(1.05);
+}
+
+.gallery-card__badge,
+.photo-card__badge {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  border-radius: 999px;
+  padding: 0.1rem 0.5rem;
+  background-color: rgba(0, 0, 0, 0.5);
+  color: #f8fafc;
+  font-size: 0.6rem;
+  font-weight: 600;
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.gallery-card:hover .gallery-card__badge,
+.photo-card:hover .photo-card__badge {
+  opacity: 1;
+}
+
+.gallery-card__meta {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  padding: 2rem;
+  color: #fff;
+  opacity: 0;
+  transition: opacity 300ms ease;
+}
+
+.gallery-card:hover .gallery-card__meta {
+  opacity: 1;
+}
+
+.text-meta {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+body[data-theme='light'] .text-meta {
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.text-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: inherit;
+}
+
+.photo-card__overlay,
+.gallery-card__overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  transition: box-shadow 400ms ease;
+}
+
+.gallery-card__overlay--dark,
+.photo-card__overlay--dark {
+  box-shadow: inset 0 0 40px 20px rgba(0, 0, 0, 0.8);
+}
+
+.gallery-card__overlay--light,
+.photo-card__overlay--light {
+  box-shadow: inset 0 0 28px 18px rgba(15, 23, 42, 0.22);
+}
+
+.clock,
+.counter,
+.date-indicator {
+  position: absolute;
+  font-family: 'JetBrains Mono', 'IBM Plex Mono', monospace;
+  font-size: 0.85rem;
+  letter-spacing: 0.3em;
+  color: rgba(148, 163, 184, 0.7);
+  pointer-events: none;
+  z-index: 20;
+}
+
+.clock {
+  bottom: var(--app-shell-spacing-lg);
+  left: var(--app-shell-spacing-lg);
+}
+
+.date-indicator {
+  bottom: var(--app-shell-spacing-lg);
+  right: var(--app-shell-spacing-lg);
+}
+
+.counter {
+  top: var(--app-shell-spacing-lg);
+  right: var(--app-shell-spacing-lg);
+}
+
+.app-shell.is-mobile .clock,
+.app-shell.is-mobile .date-indicator,
+.app-shell.is-mobile .counter {
+  display: none;
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 0.75rem;
+  color: var(--text-gray-400);
+}
+
+.empty-state__title {
+  font-size: 1.1rem;
+  font-weight: 500;
+}
+
+.empty-state__text {
+  font-size: 0.85rem;
+}
+
+.empty-state__icon {
+  width: 3rem;
+  height: 3rem;
+  color: var(--text-gray-500);
+}
+
+.screen-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background-color: rgba(0, 0, 0, 0.9);
+  transition: opacity 400ms ease;
+  pointer-events: none;
+}
+
+.screen-overlay.is-hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.screen-overlay.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.screen-overlay__media {
+  position: absolute;
+  inset: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: 1rem;
+  background-color: #000;
+  box-shadow: 0 20px 65px rgba(0, 0, 0, 0.6);
+}
+
+.login-dialog {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  z-index: 90;
+}
+
+.login-dialog__card {
+  width: min(90vw, 28rem);
+  border-radius: 1.5rem;
+  border: 1px solid var(--dialog-border);
+  background-color: var(--dialog-surface);
+  color: var(--dialog-text);
+  padding: 2.5rem;
+  box-shadow: 0 25px 80px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(20px);
+}
+
+.login-dialog__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.login-dialog__title {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 1rem;
+  color: var(--dialog-title);
+}
+
+.login-dialog__description {
+  font-size: 0.85rem;
+  color: var(--dialog-muted);
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.form-field__label {
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  font-size: 0.7rem;
+  color: var(--dialog-muted);
+}
+
+.form-field__input {
+  width: 100%;
+  border-radius: 0.75rem;
+  border: 1px solid var(--dialog-input-border);
+  background-color: var(--dialog-input-background);
+  color: var(--dialog-input-text);
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+}
+
+.form-field__input:focus-visible {
+  outline: 2px solid var(--dialog-focus-ring);
+  outline-offset: 2px;
+}
+
+.form-hint {
+  font-size: 0.65rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--dialog-muted);
+}
+
+.alert {
+  border-radius: 0.9rem;
+  padding: 0.5rem 0.85rem;
+  font-size: 0.75rem;
+}
+
+.alert--danger {
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  background-color: rgba(248, 113, 113, 0.15);
+  color: #fecaca;
+}
+
+body[data-theme='light'] .alert--danger {
+  background-color: rgba(248, 113, 113, 0.2);
+  color: #7f1d1d;
+}
+
+.auto-navigation-shield {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  cursor: default;
+}
+
+.overlay-panel {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.75);
+  z-index: 50;
+}
+
+.overlay-panel__content {
+  border-radius: 1.5rem;
+  background-color: #000;
+  padding: 2rem;
+}
+
+@media (max-width: 768px) {
+  .app-shell {
+    padding: 0;
+  }
+
+  .identity-card {
+    width: 100%;
+  }
+
+  .grid-gallery {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a dedicated `app-shell` stylesheet with semantic layout, utility, and overlay classes for the root container, panels, cards, and dialogs
- rework `app.component.html` to rely on the new classes, including semantic bindings for stateful shells, gallery/photo cards, overlays, and the admin/login UI
- wire the new stylesheet into the global style stack so the shell utilities are loaded everywhere

## Testing
- `npm run lint` *(fails: script not defined in package.json)*
- `npm run typecheck` *(fails: script not defined in package.json)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918e1414860832192de499fb123b4ce)