### PR TITLE
feat: criar estilos dedicados para captura

### DIFF
--- a/src/components/webcam-capture/webcam-capture.component.ts
+++ b/src/components/webcam-capture/webcam-capture.component.ts
@@ -8,94 +8,75 @@ import { convertToWebp } from '../../utils/convert-to-webp';
   imports: [CommonModule],
   template: `
     @if (isMobileVariant()) {
-      <div class="flex h-full flex-col">
-        <div class="flex-1 px-4 pt-8">
-          <div class="mx-auto flex h-full w-full max-w-[26rem] flex-col items-center">
-            <div class="w-full select-none" data-cursor-pointer (click)="toggleGridOverlay()">
-              <div
-                class="relative aspect-square w-full overflow-hidden rounded-3xl border border-white/10 bg-black shadow-[0_10px_40px_rgba(0,0,0,0.6)]">
-                <video
-                  #videoElement
-                  class="h-full w-full object-cover"
-                  [class.opacity-0]="!isStreaming()"
-                  autoplay
-                  playsinline>
-                </video>
+      <div
+        class="capture capture--mobile"
+        [class.capture--active]="isCaptureActive()"
+        [class.capture--grid]="showGrid()"
+        [class.capture--countdown]="countdown() !== null && countdown()! > 0">
+        <div class="capture__stage">
+          <div class="capture__stage-inner">
+            <div class="capture__viewport" data-cursor-pointer (click)="toggleGridOverlay()">
+              <video
+                #videoElement
+                class="capture__video"
+                [class.capture__video--hidden]="!isStreaming()"
+                autoplay
+                playsinline>
+              </video>
 
-                @if (!isStreaming() && !error()) {
-                  <div class="absolute inset-0 flex items-center justify-center text-sm text-gray-400">
-                    Preparando câmera...
-                  </div>
-                }
-
-                @if (error()) {
-                  <div class="absolute inset-0 flex items-center justify-center bg-black/80 px-6 text-center text-sm font-medium text-red-200">
-                    {{ error() }}
-                  </div>
-                }
-
-                <div
-                  class="pointer-events-none absolute inset-0 transition-opacity duration-300"
-                  [class.opacity-0]="!showGrid()"
-                  [class.opacity-100]="showGrid()">
-                  <div class="absolute inset-x-0 top-[33.333%] h-px bg-white/25"></div>
-                  <div class="absolute inset-x-0 top-[66.666%] h-px bg-white/25"></div>
-                  <div class="absolute inset-y-0 left-[33.333%] w-px bg-white/25"></div>
-                  <div class="absolute inset-y-0 left-[66.666%] w-px bg-white/25"></div>
+              @if (!isStreaming() && !error()) {
+                <div class="capture__status capture__status--loading">
+                  Preparando câmera...
                 </div>
+              }
 
-                @if (countdown() !== null && countdown()! > 0) {
-                  <div class="absolute inset-0 flex items-center justify-center text-6xl font-semibold text-white">
-                    {{ countdown() }}
-                  </div>
-                }
-              </div>
+              @if (error()) {
+                <div class="capture__status capture__status--error">
+                  {{ error() }}
+                </div>
+              }
+
+              <div class="capture__grid-overlay" aria-hidden="true"></div>
+
+              @if (countdown() !== null && countdown()! > 0) {
+                <div class="capture__countdown capture__countdown--mobile">
+                  {{ countdown() }}
+                </div>
+              }
             </div>
 
-            <div class="mt-3 w-full">
+            <div class="capture__gallery-slot">
               <ng-content select="[mobileGallerySelection]"></ng-content>
             </div>
           </div>
         </div>
 
-        <div class="px-8 pb-12 pt-6">
-          <div class="grid grid-cols-3 items-end gap-6 text-white">
+        <div class="capture__panel">
+          <div class="capture__control-grid">
             <button
               type="button"
               (click)="cycleTimerSetting()"
-              class="group flex flex-col items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.32em] text-white/70 transition hover:text-white focus:outline-none disabled:cursor-not-allowed"
-              [disabled]="!isStreaming()"
-              [class.opacity-50]="!isStreaming()">
-              <span
-                class="flex h-14 w-14 items-center justify-center rounded-full border border-white/15 bg-white/10 text-white shadow-[inset_0_0_18px_rgba(255,255,255,0.05)] transition group-hover:border-white/40 group-hover:bg-white/20">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="h-5 w-5">
+              class="btn btn--ghost capture__chip"
+              [disabled]="!isStreaming()">
+              <span class="capture__chip-face">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="capture__chip-icon">
                   <circle cx="12" cy="12" r="9"></circle>
                   <polyline points="12 7 12 12 15 13.5"></polyline>
                 </svg>
               </span>
-              <span class="tracking-[0.4em]">{{ timerLabel() | uppercase }}</span>
+              <span class="capture__chip-label">{{ timerLabel() | uppercase }}</span>
             </button>
 
-            <div class="flex justify-center">
+            <div class="capture__shutter-wrapper">
               <button
                 type="button"
                 (click)="captureImage()"
-                class="group relative flex aspect-square w-24 items-center justify-center rounded-[26px] bg-gradient-to-b from-[#1f1f1f] via-[#111111] to-[#050505] text-white shadow-[0_18px_35px_rgba(0,0,0,0.45)] transition-all duration-200 active:translate-y-1 disabled:cursor-not-allowed"
-                [disabled]="!isStreaming() || !captureAllowed() || isCaptureActive()"
-                [class.opacity-50]="!isStreaming() || !captureAllowed()"
-                [ngClass]="isCaptureActive() ? ['translate-y-1', '!shadow-[0_12px_24px_rgba(0,0,0,0.35)]'] : []">
-                <span
-                  class="absolute inset-0 rounded-[26px] border border-white/40 transition-all duration-200 group-hover:brightness-105 group-active:brightness-110"
-                  [ngClass]="{ 'brightness-110': isCaptureActive() }"></span>
-                <span
-                  class="absolute inset-1 rounded-[22px] bg-gradient-to-b from-[#2f2f2f] via-[#1a1a1a] to-[#090909] shadow-[inset_0_-8px_0_rgba(0,0,0,0.18)] transition-all duration-200 group-active:translate-y-0.5 group-active:shadow-[inset_0_6px_0_rgba(0,0,0,0.22)]"
-                  [ngClass]="isCaptureActive() ? ['translate-y-0.5', 'shadow-[inset_0_6px_0_rgba(0,0,0,0.22)]'] : []"></span>
-                <span
-                  class="absolute inset-[22%] rounded-[18px] bg-gradient-to-b from-[#e5e5e5] via-[#a3a3a3] to-[#3f3f3f] shadow-[0_6px_15px_rgba(0,0,0,0.25)] transition-all duration-200 group-active:translate-y-0.5 group-active:shadow-[inset_0_4px_8px_rgba(0,0,0,0.25)]"
-                  [ngClass]="isCaptureActive() ? ['translate-y-0.5', 'shadow-[inset_0_4px_8px_rgba(0,0,0,0.25)]'] : []"></span>
-                <span
-                  class="absolute inset-[46%] rounded-full bg-neutral-300/80 transition-all duration-200 group-active:translate-y-0.5"
-                  [ngClass]="{ 'translate-y-0.5': isCaptureActive() }"></span>
+                class="capture__shutter"
+                [disabled]="!isStreaming() || !captureAllowed() || isCaptureActive()">
+                <span class="capture__shutter-layer capture__shutter-layer--frame"></span>
+                <span class="capture__shutter-layer capture__shutter-layer--body"></span>
+                <span class="capture__shutter-layer capture__shutter-layer--inner"></span>
+                <span class="capture__shutter-layer capture__shutter-layer--core"></span>
                 <span class="sr-only">Capturar foto</span>
               </button>
             </div>
@@ -104,30 +85,28 @@ import { convertToWebp } from '../../utils/convert-to-webp';
               <button
                 type="button"
                 (click)="cycleCamera()"
-                class="group flex flex-col items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.32em] text-white/70 transition hover:text-white focus:outline-none disabled:cursor-not-allowed"
-                [disabled]="!isStreaming()"
-                [class.opacity-50]="!isStreaming()">
-                <span
-                  class="flex h-14 w-14 items-center justify-center rounded-full border border-white/15 bg-white/10 text-white shadow-[inset_0_0_18px_rgba(255,255,255,0.05)] transition group-hover:border-white/40 group-hover:bg-white/20">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="h-5 w-5">
+                class="btn btn--ghost capture__chip"
+                [disabled]="!isStreaming()">
+                <span class="capture__chip-face">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="capture__chip-icon">
                     <path d="M21 16.92A5.5 5.5 0 0 1 18.36 19H8"></path>
                     <path d="M3 12a5.5 5.5 0 0 1 5.5-5.5H16"></path>
                     <path d="M8 5l3-3 3 3"></path>
                     <path d="m16 19-3 3-3-3"></path>
                   </svg>
                 </span>
-                <span class="tracking-[0.4em]">CÂMERA</span>
+                <span class="capture__chip-label">CÂMERA</span>
               </button>
             } @else {
-              <div class="h-14"></div>
+              <div class="capture__control-placeholder" aria-hidden="true"></div>
             }
           </div>
 
-          <div class="mt-6 flex justify-center">
+          <div class="capture__panel-refresh">
             <button
               type="button"
               (click)="reloadApp()"
-              class="inline-flex items-center gap-1 rounded-full border border-white/10 px-3 py-1 text-[10px] font-medium uppercase tracking-[0.3em] text-white/40 transition hover:border-white/20 hover:text-white/70 focus:outline-none"
+              class="btn btn--ghost capture__refresh"
               title="Atualizar aplicativo">
               Atualizar aplicativo
             </button>
@@ -138,7 +117,10 @@ import { convertToWebp } from '../../utils/convert-to-webp';
       </div>
     } @else {
       <div
-      class="backdrop-blur-sm rounded-lg p-6 shadow-2xl w-full max-w-lg animate-slide-up relative"
+      class="capture capture--dialog backdrop-blur-sm rounded-lg p-6 shadow-2xl w-full max-w-lg animate-slide-up relative"
+      [class.capture--active]="isCaptureActive()"
+      [class.capture--countdown]="countdown() !== null && countdown()! > 0"
+      [class.capture--grid]="showGrid()"
       [style.backgroundColor]="themeService.dialogPalette().surface"
       [style.border]="'1px solid ' + themeService.dialogPalette().border"
       [style.color]="themeService.dialogPalette().text"
@@ -196,7 +178,7 @@ import { convertToWebp } from '../../utils/convert-to-webp';
 
           @if (countdown() !== null && countdown()! > 0) {
             <div
-              class="absolute inset-0 flex items-center justify-center text-9xl font-bold z-20"
+              class="capture__countdown capture__countdown--dialog"
               [style.color]="themeService.isDark() ? '#ffffff' : '#0f172a'">
               {{ countdown() }}
             </div>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -3,6 +3,7 @@
 @import './components/card.css';
 @import './components/menu.css';
 @import './components/app-shell.css';
+@import './components/capture.css';
 
 *, *::before, *::after {
   box-sizing: border-box;

--- a/src/styles/components/capture.css
+++ b/src/styles/components/capture.css
@@ -1,0 +1,319 @@
+.capture {
+  --capture-text: var(--text-inverse);
+  --capture-muted: var(--text-inverse-70);
+  --capture-border: rgba(255, 255, 255, 0.08);
+  --capture-panel-bg: transparent;
+  --capture-grid-color: rgba(255, 255, 255, 0.25);
+  color: var(--capture-text);
+}
+
+[data-theme='light'] .capture {
+  --capture-border: rgba(15, 23, 42, 0.18);
+  --capture-grid-color: rgba(15, 23, 42, 0.45);
+}
+
+.capture--mobile {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  background: transparent;
+}
+
+.capture__stage {
+  flex: 1;
+  padding: 2rem 1.25rem 0;
+  display: flex;
+  justify-content: center;
+}
+
+.capture__stage-inner {
+  width: 100%;
+  max-width: 26rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.capture__viewport {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: var(--radius-3xl, 1.875rem);
+  border: 1px solid var(--capture-border);
+  overflow: hidden;
+  background: linear-gradient(180deg, #050505 0%, #000000 100%);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.6);
+  cursor: pointer;
+  user-select: none;
+}
+
+.capture__video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: opacity 200ms ease;
+}
+
+.capture__video.capture__video--hidden {
+  opacity: 0;
+}
+
+.capture__status {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.capture__status--loading {
+  color: var(--capture-muted);
+}
+
+.capture__status--error {
+  background: rgba(0, 0, 0, 0.75);
+  color: #fecaca;
+}
+
+.capture__grid-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 200ms ease;
+  background-image: linear-gradient(
+      to right,
+      transparent 0,
+      transparent calc(33.333% - 0.5px),
+      var(--capture-grid-color) calc(33.333% - 0.5px),
+      var(--capture-grid-color) calc(33.333% + 0.5px),
+      transparent calc(33.333% + 0.5px),
+      transparent calc(66.666% - 0.5px),
+      var(--capture-grid-color) calc(66.666% - 0.5px),
+      var(--capture-grid-color) calc(66.666% + 0.5px),
+      transparent calc(66.666% + 0.5px)
+    ),
+    linear-gradient(
+      to bottom,
+      transparent 0,
+      transparent calc(33.333% - 0.5px),
+      var(--capture-grid-color) calc(33.333% - 0.5px),
+      var(--capture-grid-color) calc(33.333% + 0.5px),
+      transparent calc(33.333% + 0.5px),
+      transparent calc(66.666% - 0.5px),
+      var(--capture-grid-color) calc(66.666% - 0.5px),
+      var(--capture-grid-color) calc(66.666% + 0.5px),
+      transparent calc(66.666% + 0.5px)
+    );
+}
+
+.capture--grid .capture__grid-overlay {
+  opacity: 1;
+}
+
+.capture__countdown {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  color: var(--text-inverse);
+  text-shadow: 0 8px 35px rgba(0, 0, 0, 0.45);
+}
+
+.capture__countdown--mobile {
+  font-size: clamp(3rem, 15vw, 4.5rem);
+}
+
+.capture__countdown--dialog {
+  font-size: clamp(4rem, 12vw, 8rem);
+}
+
+.capture__gallery-slot {
+  width: 100%;
+  margin-top: 0.75rem;
+}
+
+.capture__panel {
+  padding: 1.5rem 2rem 3rem;
+  color: var(--capture-text);
+}
+
+.capture__control-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.5rem;
+  align-items: flex-end;
+}
+
+.capture__chip {
+  width: 100%;
+  height: 5.5rem;
+  padding: 0;
+  margin: 0;
+  border: none;
+  background: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.35rem;
+  letter-spacing: 0.32em;
+  font-size: 0.625rem;
+  color: var(--capture-muted);
+}
+
+.capture__chip .capture__chip-face {
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.08);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--capture-text);
+  box-shadow: inset 0 0 18px rgba(255, 255, 255, 0.05);
+  transition: border-color 200ms ease, background-color 200ms ease, color 200ms ease;
+}
+
+[data-theme='light'] .capture__chip .capture__chip-face {
+  border-color: rgba(15, 23, 42, 0.3);
+  background: rgba(15, 23, 42, 0.08);
+  box-shadow: inset 0 0 18px rgba(15, 23, 42, 0.08);
+}
+
+.capture__chip-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.capture__chip:not(:disabled):hover .capture__chip-face {
+  border-color: rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.capture__chip:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.capture__chip-label {
+  display: inline-block;
+}
+
+.capture__shutter-wrapper {
+  display: flex;
+  justify-content: center;
+}
+
+.capture__shutter {
+  position: relative;
+  width: 6rem;
+  aspect-ratio: 1 / 1;
+  border: none;
+  border-radius: var(--radius-2xl, 1.625rem);
+  background: linear-gradient(180deg, #1f1f1f 0%, #050505 100%);
+  box-shadow: var(--shadow-soft);
+  cursor: pointer;
+  transition: transform 200ms ease, box-shadow 200ms ease, filter 200ms ease;
+}
+
+.capture__shutter:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.capture__shutter-layer {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  transition: transform 200ms ease, box-shadow 200ms ease, filter 200ms ease;
+}
+
+.capture__shutter-layer--frame {
+  border: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+.capture__shutter-layer--body {
+  inset: 0.35rem;
+  border-radius: calc(var(--radius-2xl, 1.625rem) - 0.25rem);
+  background: linear-gradient(180deg, #2f2f2f 0%, #090909 100%);
+  box-shadow: var(--shadow-soft-inner);
+}
+
+.capture__shutter-layer--inner {
+  inset: 1.35rem;
+  border-radius: var(--radius-xl, 1.25rem);
+  background: linear-gradient(180deg, #e5e5e5 0%, #3f3f3f 100%);
+  box-shadow: 0 6px 15px rgba(0, 0, 0, 0.25);
+}
+
+.capture__shutter-layer--core {
+  inset: 2.1rem;
+  border-radius: 50%;
+  background: rgba(224, 224, 224, 0.85);
+}
+
+.capture--active .capture__shutter {
+  transform: translateY(2px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.35);
+}
+
+.capture--active .capture__shutter-layer--body,
+.capture--active .capture__shutter-layer--inner,
+.capture--active .capture__shutter-layer--core {
+  transform: translateY(2px);
+  box-shadow: inset 0 6px 0 rgba(0, 0, 0, 0.22);
+}
+
+.capture__control-placeholder {
+  height: 3.5rem;
+  width: 100%;
+}
+
+.capture__panel-refresh {
+  margin-top: 1.5rem;
+  display: flex;
+  justify-content: center;
+}
+
+.capture__refresh {
+  border-radius: 999px;
+  padding: 0.35rem 1rem;
+  font-size: 0.625rem;
+  letter-spacing: 0.3em;
+  color: rgba(255, 255, 255, 0.6);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.capture__refresh:not(:disabled):hover {
+  color: rgba(255, 255, 255, 0.75);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+.capture--countdown .capture__viewport::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle, rgba(0, 0, 0, 0) 50%, rgba(0, 0, 0, 0.35) 100%);
+  pointer-events: none;
+}
+
+.capture--dialog .capture__countdown {
+  color: currentColor;
+}
+
+@media (min-width: 768px) {
+  .capture--dialog .capture__countdown {
+    font-size: clamp(5rem, 6vw, 8rem);
+  }
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -89,6 +89,11 @@
   --surface-overlay-20: rgba(255, 255, 255, 0.2);
   --surface-slate-700: #374151;
   --surface-slate-700-text: inherit;
+  --radius-xl: 1.25rem;
+  --radius-2xl: 1.625rem;
+  --radius-3xl: 1.875rem;
+  --shadow-soft: 0 18px 35px rgba(0, 0, 0, 0.45);
+  --shadow-soft-inner: inset 0 -8px 0 rgba(0, 0, 0, 0.18);
 
   /* Frequently reused text tokens */
   --text-inverse: #ffffff;
@@ -188,6 +193,11 @@
   --surface-overlay-20: rgba(15, 23, 42, 0.14);
   --surface-slate-700: rgba(148, 163, 184, 0.35);
   --surface-slate-700-text: #0f172a;
+  --radius-xl: 1.25rem;
+  --radius-2xl: 1.625rem;
+  --radius-3xl: 1.875rem;
+  --shadow-soft: 0 18px 35px rgba(15, 23, 42, 0.18);
+  --shadow-soft-inner: inset 0 -8px 0 rgba(15, 23, 42, 0.12);
 
   --text-inverse: #0f172a;
   --text-inverse-90: rgba(15, 23, 42, 0.88);


### PR DESCRIPTION
## Summary
- adiciona um pacote de estilos dedicado (`capture.css`) com gradientes, overlays, botões e responsividade para o fluxo de captura
- troca a marcação mobile do componente para usar as novas classes, estados booleanos e botões baseados em `.btn`, alem de reutilizar as classes na variante dialog
- expande os tokens globais com raios e sombras usados pelos novos elementos

## Testing
- npm run lint *(fails: Missing script "lint")*
- npm run typecheck *(fails: Missing script "typecheck")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918e3f839b48321aa20a9b6a413d353)