### PR TITLE
Ajusta badges de galeria no mobile

### DIFF
--- a/src/components/mobile-gallery-card/mobile-gallery-card.component.ts
+++ b/src/components/mobile-gallery-card/mobile-gallery-card.component.ts
@@ -28,9 +28,9 @@ import { Gallery } from '../../interfaces/gallery.interface';
         </p>
         <div class="card__meta">
           @if (gallery().createdAt) {
-            <span class="badge badge--mono card__badge">{{ gallery().createdAt }}</span>
+            <span class="badge badge--mono card__badge">{{ formatCreatedAt(gallery().createdAt) }}</span>
           }
-          <span class="badge badge--mono card__badge">{{ gallery().imageUrls.length }} fotos</span>
+          <span class="badge badge--mono card__badge">{{ gallery().imageUrls.length }}</span>
         </div>
       </div>
       <button
@@ -88,5 +88,19 @@ export class MobileGalleryCardComponent {
   handleOpen(event: MouseEvent): void {
     event.stopPropagation();
     this.open.emit();
+  }
+
+  formatCreatedAt(value?: string): string | undefined {
+    if (!value) {
+      return undefined;
+    }
+
+    const [day, month, year] = value.split('/');
+    if (!day || !month || !year) {
+      return value;
+    }
+
+    const shortYear = year.slice(-2);
+    return `${day}/${month}/${shortYear}`;
   }
 }


### PR DESCRIPTION
## Summary
- Remove a palavra "fotos" da badge de quantidade nas galerias móveis, exibindo apenas o número.
- Formata a data da galeria para mostrar apenas dois dígitos do ano na visualização móvel.

## Testing
- npm run lint *(falhou: script ausente no projeto)*
- npm run typecheck *(falhou: script ausente no projeto)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918fb23a8dc83219b20391320c7f439)