### PR TITLE
Ocultar canvas de captura da interface

### DIFF
--- a/src/components/webcam-capture/webcam-capture.component.ts
+++ b/src/components/webcam-capture/webcam-capture.component.ts
@@ -113,7 +113,10 @@ import { convertToWebp } from '../../utils/convert-to-webp';
           </div>
         </div>
 
-        <canvas #canvasElement class="hidden"></canvas>
+        <canvas
+          #canvasElement
+          class="capture__canvas"
+          aria-hidden="true"></canvas>
       </div>
     } @else {
       <div
@@ -249,7 +252,10 @@ import { convertToWebp } from '../../utils/convert-to-webp';
           </div>
         </div>
 
-        <canvas #canvasElement class="hidden"></canvas>
+        <canvas
+          #canvasElement
+          class="capture__canvas"
+          aria-hidden="true"></canvas>
       </div>
     }
   `,
@@ -274,6 +280,10 @@ import { convertToWebp } from '../../utils/convert-to-webp';
 
     button:not(:disabled):hover {
       filter: brightness(1.05);
+    }
+
+    .capture__canvas {
+      display: none;
     }
   `],
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
## Summary
- ajusta o componente de captura para esconder o canvas interno utilizado na geração das imagens
- marca o canvas como oculto para evitar que o preview apareça na interface móvel ou no modal

## Testing
- npm run lint *(falha: script "lint" não definido no projeto)*
- npm run typecheck *(falha: script "typecheck" não definido no projeto)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918fcf05da88321a2cffa1bb8283fac)