### PR TITLE
Fix mobile gallery detail icons

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -219,9 +219,11 @@
               aria-label="Voltar para galerias"
               (click)="returnToMobileGalleries()">
               <span class="sr-only">Voltar para galerias</span>
-              <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12l7.5-7.5M3 12h18" />
-              </svg>
+              <span class="button__icon" aria-hidden="true">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12l7.5-7.5M3 12h18" />
+                </svg>
+              </span>
             </button>
             <div class="mobile-shell__actions">
               @if (canManageContent()) {
@@ -239,9 +241,11 @@
                   [disabled]="!activeGallery()"
                   (click)="deleteActiveGalleryFromMobile()">
                   <span class="sr-only">Excluir galeria</span>
-                  <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673A2.25 2.25 0 0 1 15.916 21.75H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-                  </svg>
+                  <span class="button__icon" aria-hidden="true">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673A2.25 2.25 0 0 1 15.916 21.75H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                    </svg>
+                  </span>
                 </button>
               } @else {
                 <span class="badge badge--mono badge--muted">Somente visualização</span>

--- a/src/styles/components/app-shell.css
+++ b/src/styles/components/app-shell.css
@@ -380,6 +380,19 @@ body[data-theme='light'] .button--danger {
   border-radius: 999px;
 }
 
+.button__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.button__icon svg {
+  width: 100%;
+  height: 100%;
+}
+
 .app-shell__back-button {
   position: absolute;
   top: var(--app-shell-spacing-lg);


### PR DESCRIPTION
## Summary
- add explicit icon containers for the mobile gallery detail back and delete buttons to restore icon rendering
- ensure icon sizing via shared button__icon style so glyphs stay visible on mobile actions

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918fd6975d48321a6cf81f9c3117876)