### PR TITLE
Ajusta bordas do contêiner do app

### DIFF
--- a/src/app.component.css
+++ b/src/app.component.css
@@ -1,6 +1,14 @@
 :host {
   display: block;
   width: 100vw;
-  height: 100vh;
+  min-height: 100vh;
+  padding: var(--app-shell-spacing-lg);
+  box-sizing: border-box;
   user-select: none;
+}
+
+@media (max-width: 768px) {
+  :host {
+    padding: 0;
+  }
 }


### PR DESCRIPTION
## Summary
- adiciona padding e box-sizing ao host principal para recuperar as bordas do layout no desktop
- remove o padding em telas pequenas para manter a experiência móvel em tela cheia

## Testing
- npm run lint *(indisponível: script ausente)*
- npm run typecheck *(indisponível: script ausente)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919100759908321a2fc661988c5fc56)