### PR TITLE
Prevent closing webcam dialog after captures

### DIFF
--- a/src/components/webcam-capture/webcam-capture.component.ts
+++ b/src/components/webcam-capture/webcam-capture.component.ts
@@ -541,9 +541,6 @@ export class WebcamCaptureComponent implements AfterViewInit, OnDestroy {
       try {
         const dataUrl = await this.blobToDataUrl(blob);
         this.capture.emit(dataUrl);
-        if (!this.isMobileVariant()) {
-          this.close.emit();
-        }
       } catch (error) {
         console.error('Erro ao gerar pré-visualização da captura', error);
         this.error.set('Não foi possível processar a imagem capturada.');


### PR DESCRIPTION
## Summary
- remove automatic closing of the webcam capture dialog after a photo is taken so users can keep capturing

## Testing
- npm run lint *(fails: script not found)*
- npm run typecheck *(fails: script not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69192e16452c83218acc0c40df620daa)