### PR TITLE
Corrige posicionamento e dimensionamento da imagem expandida

### DIFF
--- a/src/styles/components/app-shell.css
+++ b/src/styles/components/app-shell.css
@@ -818,7 +818,8 @@ body[data-theme='light'] .photo-mosaic__border {
 
 .screen-overlay__media {
   position: absolute;
-  inset: 50%;
+  top: 50%;
+  left: 50%;
   transform: translate(-50%, -50%);
   display: flex;
   align-items: center;
@@ -827,6 +828,8 @@ body[data-theme='light'] .photo-mosaic__border {
   border-radius: 1rem;
   background-color: #000;
   box-shadow: 0 20px 65px rgba(0, 0, 0, 0.6);
+  max-width: 90vw;
+  max-height: 90vh;
 }
 
 .screen-overlay__image {


### PR DESCRIPTION
## Summary
- centraliza o contêiner da foto expandida sem sobrescrever largura e altura
- limita o tamanho máximo da mídia expandida a 90% da viewport para manter proporção e visibilidade

## Testing
- npm run lint *(falha: script ausente no projeto)*
- npm run typecheck *(falha: script ausente no projeto)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691934b67ad883218cd1da189732f44d)