### PR TITLE
Garantir proporcao 1x1 na galeria mobile

### DIFF
--- a/src/components/webcam-capture/webcam-capture.component.ts
+++ b/src/components/webcam-capture/webcam-capture.component.ts
@@ -400,10 +400,16 @@ export class WebcamCaptureComponent implements AfterViewInit, OnDestroy {
         throw new Error('A API de mídia do navegador não está disponível.');
       }
 
+      const commonVideoConstraints: MediaTrackConstraints = {
+        aspectRatio: 1,
+        width: { ideal: 1280 },
+        height: { ideal: 1280 },
+      };
+
       const constraints: MediaStreamConstraints = {
         video: this.selectedCameraId()
-          ? { deviceId: { exact: this.selectedCameraId()! } }
-          : { facingMode: 'environment' },
+          ? { ...commonVideoConstraints, deviceId: { exact: this.selectedCameraId()! } }
+          : { ...commonVideoConstraints, facingMode: 'environment' },
       };
 
       this.stream = await navigator.mediaDevices.getUserMedia(constraints);

--- a/src/styles/components/app-shell.css
+++ b/src/styles/components/app-shell.css
@@ -625,6 +625,8 @@ body[data-theme='light'] .meta-label {
   background-color: var(--surface-muted);
   cursor: pointer;
   transition: transform 200ms ease, box-shadow 200ms ease;
+  display: grid;
+  align-items: stretch;
 }
 
 body[data-theme='light'] .photo-mosaic__item {
@@ -640,6 +642,8 @@ body[data-theme='light'] .photo-mosaic__item {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  aspect-ratio: 1 / 1;
+  display: block;
   transition: transform 400ms ease;
 }
 


### PR DESCRIPTION
## Summary
- aplica constraints 1:1 na câmera móvel para capturar quadros quadrados
- reforça o layout dos itens da galeria móvel para manter imagens quadradas sem distorção

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691940d0fdc8832199b0269722425aec)