### PR TITLE
Adiciona menu de avatar para usuário logado

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -7,27 +7,77 @@
   (contextmenu)="onRightClick($event)">
 
   <div class="app-shell__viewport">
-  @if (canManageContent()) {
-    <div
-      class="app-shell__admin-panel"
-      [class.app-shell__admin-panel--mobile]="isMobileLayout()">
-      <div
-        class="identity-card"
-        [class.identity-card--mobile]="isMobileLayout()">
-        <span class="identity-card__name" [title]="authUserEmail() ?? undefined">{{ authUserEmail() }}</span>
-        <span class="identity-card__role">Admin</span>
-        <button
-          type="button"
-          data-cursor-pointer
-          class="identity-card__action"
-          (click)="signOut()">
-          Sair
-        </button>
-      </div>
-    </div>
-  }
+    <ng-template #userMenu>
+      @if (canManageContent()) {
+        <div class="user-menu" #userMenuRoot>
+          <button
+            type="button"
+            data-cursor-pointer
+            class="user-menu__trigger"
+            aria-label="Menu do usuário"
+            [attr.aria-expanded]="isUserMenuOpen()"
+            (click)="toggleUserMenu($event)">
+            <svg xmlns="http://www.w3.org/2000/svg" class="icon icon--md" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
+              <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 20.25a8.25 8.25 0 0 1 15 0" />
+            </svg>
+          </button>
 
-  @if (isMobileLayout()) {
+          @if (isUserMenuOpen()) {
+            <div class="user-menu__dropdown">
+              <div class="user-menu__header">
+                <div class="user-menu__avatar">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="icon icon--sm" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 20.25a8.25 8.25 0 0 1 15 0" />
+                  </svg>
+                </div>
+                <div class="user-menu__details">
+                  <span class="user-menu__email" [title]="authUserEmail() ?? undefined">{{ authUserEmail() }}</span>
+                  <span class="user-menu__role">{{ userRoleLabel() }}</span>
+                </div>
+              </div>
+
+              <div class="user-menu__actions">
+                <button
+                  type="button"
+                  class="button button--ghost user-menu__action"
+                  data-cursor-pointer
+                  (click)="refreshApp()">
+                  Atualizar aplicativo
+                </button>
+                <button
+                  type="button"
+                  class="button button--ghost user-menu__action"
+                  data-cursor-pointer
+                  (click)="signOut()">
+                  Sair
+                </button>
+              </div>
+            </div>
+          }
+        </div>
+      }
+    </ng-template>
+
+    @if (!isMobileLayout()) {
+      <div class="app-shell__status-bar">
+        <div class="counter">
+          @if (currentView() === 'galleries') {
+            {{ galleryCounterLabel() }} {{ galleryCount() }}
+          } @else {
+            {{ photoCounterLabel() }} {{ photoCount() }}
+          }
+        </div>
+        <ng-container [ngTemplateOutlet]="userMenu"></ng-container>
+      </div>
+    } @else if (mobileView() === 'capture') {
+      <div class="app-shell__status-bar app-shell__status-bar--mobile">
+        <ng-container [ngTemplateOutlet]="userMenu"></ng-container>
+      </div>
+    }
+
+    @if (isMobileLayout()) {
     @switch (mobileView()) {
       @case ('capture') {
         <div class="mobile-shell mobile-shell--capture">
@@ -447,15 +497,6 @@
     </div>
     <div class="date-indicator">
       {{ currentDate() }}
-    </div>
-
-    <!-- Contador de Galerias ou Fotos -->
-    <div class="counter">
-      @if (currentView() === 'galleries') {
-        {{ galleryCounterLabel() }} {{ galleryCount() }}
-      } @else {
-        {{ photoCounterLabel() }} {{ photoCount() }}
-      }
     </div>
 
     @if (currentView() === 'photos' && !isIdle()) {

--- a/src/styles/components/app-shell.css
+++ b/src/styles/components/app-shell.css
@@ -56,91 +56,126 @@ body[data-theme='light'] {
   height: 100%;
 }
 
-.app-shell__admin-panel {
+.app-shell__status-bar {
   position: absolute;
   top: var(--app-shell-spacing-lg);
   right: var(--app-shell-spacing-lg);
   display: flex;
-  flex-direction: column;
-  gap: var(--app-shell-spacing-sm);
-  z-index: 40;
-  pointer-events: none;
-}
-
-.app-shell__admin-panel.app-shell__admin-panel--mobile {
-  position: fixed;
-  inset-inline: 0;
-  bottom: 0;
-  top: auto;
-  padding: 0 var(--app-shell-spacing-md) var(--app-shell-spacing-md);
-  align-items: stretch;
-}
-
-.identity-card {
-  pointer-events: auto;
-  display: flex;
   align-items: center;
-  gap: var(--app-shell-spacing-sm);
-  width: max-content;
-  border-radius: var(--app-shell-toolbar-radius);
+  gap: var(--app-shell-spacing-md);
+  z-index: 40;
+}
+
+.app-shell__status-bar--mobile {
+  position: fixed;
+  inset-inline: auto var(--app-shell-spacing-md);
+  top: var(--app-shell-spacing-md);
+}
+
+.user-menu {
+  position: relative;
+}
+
+.user-menu__trigger {
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 999px;
   border: 1px solid var(--app-shell-border);
   background-color: var(--app-shell-panel-bg);
   color: var(--app-shell-panel-text);
-  padding: var(--app-shell-spacing-sm) var(--app-shell-spacing-md);
-  font-size: 0.65rem;
-  font-weight: 600;
-  letter-spacing: 0.24em;
-  text-transform: uppercase;
-  box-shadow: 0 25px 60px rgba(0, 0, 0, 0.3);
-  backdrop-filter: blur(14px);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+  transition: transform 150ms ease, box-shadow 150ms ease;
 }
 
-.identity-card.identity-card--mobile {
-  border-radius: 1.5rem 1.5rem 0 0;
-  width: 100%;
-  justify-content: space-between;
+.user-menu__trigger:hover,
+.user-menu__trigger:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 25px 60px rgba(0, 0, 0, 0.4);
 }
 
-.identity-card__name {
+.user-menu__trigger:focus-visible {
+  outline: 2px solid var(--app-shell-border);
+  outline-offset: 3px;
+}
+
+.user-menu__dropdown {
+  position: absolute;
+  top: calc(100% + var(--app-shell-spacing-sm));
+  right: 0;
+  min-width: 16rem;
+  border-radius: 1rem;
+  border: 1px solid var(--app-shell-border);
+  background-color: var(--app-shell-panel-bg);
+  color: var(--app-shell-panel-text);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.45);
+  padding: var(--app-shell-spacing-md);
+  display: grid;
+  gap: var(--app-shell-spacing-md);
+}
+
+.user-menu__header {
+  display: flex;
+  align-items: center;
+  gap: var(--app-shell-spacing-sm);
+}
+
+.user-menu__avatar {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  border: 1px solid var(--app-shell-border);
+  background-color: var(--surface-overlay-20);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: inherit;
+}
+
+.user-menu__details {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.user-menu__email {
+  font-weight: 700;
   font-size: 0.9rem;
-  letter-spacing: normal;
-  text-transform: none;
-  max-width: 12rem;
+  max-width: 18rem;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.identity-card__role {
-  border-radius: 999px;
-  padding: 0.1rem 0.75rem;
-  background-color: var(--surface-overlay-20);
-  color: inherit;
-  font-size: 0.55rem;
+.user-menu__role {
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--text-muted);
 }
 
-.identity-card__action {
+.user-menu__actions {
+  display: grid;
+  gap: var(--app-shell-spacing-sm);
+}
+
+.user-menu__action {
+  justify-content: center;
+  width: 100%;
   border-radius: var(--app-shell-toolbar-radius);
-  border: 1px solid currentColor;
-  padding: 0.35rem 1rem;
-  background: transparent;
-  color: inherit;
-  letter-spacing: 0.32em;
-  font-size: 0.6rem;
-  cursor: pointer;
-  transition: background-color 200ms ease, color 200ms ease;
+  border: 1px solid var(--app-shell-border);
+  color: var(--app-shell-panel-text);
+  background-color: var(--app-shell-panel-bg);
 }
 
-.identity-card__action:focus-visible {
-  outline: 2px solid currentColor;
-  outline-offset: 2px;
+.user-menu__action:hover {
+  background-color: rgba(255, 255, 255, 0.06);
 }
 
-.identity-card__action:hover {
-  background-color: rgba(255, 255, 255, 0.1);
-}
-
-body[data-theme='light'] .identity-card__action:hover {
-  background-color: rgba(15, 23, 42, 0.1);
+body[data-theme='light'] .user-menu__action:hover {
+  background-color: rgba(15, 23, 42, 0.06);
 }
 
 .mobile-shell {
@@ -690,6 +725,13 @@ body[data-theme='light'] .photo-mosaic__border {
 .counter {
   top: var(--app-shell-spacing-lg);
   right: var(--app-shell-spacing-lg);
+}
+
+.app-shell__status-bar .counter {
+  position: static;
+  right: auto;
+  top: auto;
+  color: var(--app-shell-panel-text);
 }
 
 .app-shell.is-mobile .clock,


### PR DESCRIPTION
## Summary
- substitui o cartão de identidade por um botão de avatar com dropdown para o usuário logado
- posiciona o avatar no canto superior direito (desktop e captura mobile) com contador de galerias/fotos à esquerda no desktop
- inclui ações de exibir tipo de usuário, atualizar aplicativo e sair no menu

## Testing
- npm run lint *(falhou: script não existe neste projeto)*
- npm run typecheck *(falhou: script não existe neste projeto)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919498d429c832186b0ceccec6ce11b)