### PR TITLE
Fix avatar menu dropdown opening

### DIFF
--- a/src/app.component.html
+++ b/src/app.component.html
@@ -9,7 +9,7 @@
   <div class="app-shell__viewport">
     <ng-template #userMenu>
       @if (canManageContent()) {
-        <div class="user-menu" #userMenuRoot>
+        <div class="user-menu">
           <button
             type="button"
             data-cursor-pointer

--- a/src/app.component.ts
+++ b/src/app.component.ts
@@ -504,13 +504,9 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
       return;
     }
 
-    const menuElement = this.userMenuRoot()?.nativeElement;
-    if (!menuElement) {
-      this.isUserMenuOpen.set(false);
-      return;
-    }
+    const target = event.target as HTMLElement | null;
 
-    if (!menuElement.contains(event.target as Node)) {
+    if (!target || !target.closest('.user-menu')) {
       this.isUserMenuOpen.set(false);
     }
   }
@@ -584,7 +580,6 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
   authUserEmail = computed(() => this.authService.session()?.user?.email ?? null);
   userRoleLabel = computed(() => (this.canManageContent() ? 'Admin' : 'Usuário'));
   isUserMenuOpen = signal(false);
-  userMenuRoot = viewChild<ElementRef<HTMLElement>>('userMenuRoot');
 
   isLoginDialogVisible = signal(false);
   loginEmail = signal('');


### PR DESCRIPTION
## Summary
- ensure the avatar dropdown stays open by detecting outside clicks via the menu container instead of a missing view query
- remove the unused user menu template reference used for the previous detection approach

## Testing
- npm run lint *(fails: missing script)*
- npm run typecheck *(fails: missing script)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69194c931d148321b694105901488dda)